### PR TITLE
chore: tier 3 test and quality polish

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,6 @@
 
 
 echo "🔍 Running pre-commit checks..."
-# npx lint-staged
 
 echo "🧹 Running typecheck (pnpm run typecheck)..."
 pnpm run typecheck
@@ -17,8 +16,5 @@ else
 fi
 
 pnpm exec biome format .
-# If you later enable lint-staged
-# echo "🎯 Running lint-staged..."
-# npx lint-staged
 
 echo "🎉 Pre-commit checks passed successfully!"

--- a/TODO.md
+++ b/TODO.md
@@ -19,8 +19,7 @@ Living checklist of issues, gaps, and improvements for `@rtorcato/js-common`. It
   - Fix: add `"engines": { "node": ">=18" }` to `package.json`.
 - [ ] **No `.nvmrc`.** Contributors won't auto-switch Node.
   - Fix: add `.nvmrc` matching CI (Node 22).
-- [ ] **Dead `lint-staged` + `husky.hooks` config in `package.json`.** The actual `.husky/pre-commit` runs `pnpm typecheck && pnpm check` directly, bypassing lint-staged.
-  - Fix: either wire lint-staged in (faster commits) or remove the unused `lint-staged` and `husky.hooks` blocks.
+- [x] **Dead `lint-staged` + `husky.hooks` config in `package.json`.** Resolved: removed the unused `lint-staged` and `husky.hooks` blocks plus the `lint-staged` devDependency; `.husky/pre-commit` keeps its current full-repo `pnpm typecheck && pnpm check` flow.
 
 ## 3. Code organization
 
@@ -33,12 +32,9 @@ Living checklist of issues, gaps, and improvements for `@rtorcato/js-common`. It
 
 ## 4. Tests & coverage
 
-- [ ] **`src/cli/` has no tests.**
-  - Fix: smoke test that the binary builds, prints `--help`, and exits 0.
-- [ ] **`src/types/` and `src/tests/` have no tests.** `types/` is type-only (OK); `tests/` looks like fixtures.
-  - Fix: rename `src/tests/` to `__fixtures__` or move fixtures into the modules that use them.
-- [ ] **No explicit coverage thresholds.** `vitest.config.mjs` only extends the shared tooling config.
-  - Fix: add explicit thresholds (e.g., 80% lines/branches/functions/statements) so regressions fail CI.
+- [x] **`src/cli/` has no tests.** Resolved: `src/cli/cli.test.ts` spawns the built `dist/cli/index.mjs` and asserts `--version`, `--help`, and `date today` each exit 0 with expected output.
+- [x] **`src/tests/` looks like fixtures.** Resolved: the lone trivial placeholder was deleted and the directory removed. `src/types/` remains type-only by design.
+- [x] **No explicit coverage thresholds.** Resolved: `vitest.config.mjs` now sets `lines: 85`, `statements: 85`, `functions: 95`, `branches: 70` — a no-regression floor under today's measured coverage (89.8 / 89.74 / 97.41 / 73.79).
 - [ ] **No coverage badge in README.**
 
 ## 5. Documentation
@@ -67,5 +63,3 @@ Living checklist of issues, gaps, and improvements for `@rtorcato/js-common`. It
 - `src/formatting/` — unexported (§1)
 - `CLAUDE.md` — stale `obects` note (§1)
 - `SECURITY.md` — incorrect "no runtime deps" claim (§5)
-- `vitest.config.mjs` — coverage thresholds (§4)
-- `.husky/pre-commit` — lint-staged dead code (§2)

--- a/package.json
+++ b/package.json
@@ -261,7 +261,6 @@
     "husky": "^9.1.7",
     "jsdom": "^29.0.1",
     "knip": "^6.14.2",
-    "lint-staged": "^16.2.6",
     "rimraf": "^6.0.1",
     "semantic-release": "^25.0.1",
     "typescript": "^6.0.2",
@@ -287,18 +286,6 @@
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"
-    }
-  },
-  "lint-staged": {
-    "*.{js,ts,json,md}": [
-      "pnpm exec biome lint",
-      "pnpm exec biome format",
-      "git add"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
     }
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ importers:
       knip:
         specifier: ^6.14.2
         version: 6.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      lint-staged:
-        specifier: ^16.2.6
-        version: 16.4.0
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1,0 +1,51 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const binPath = resolve(here, '../../dist/cli/index.mjs')
+const pkgPath = resolve(here, '../../package.json')
+
+const binExists = existsSync(binPath)
+const describeIfBuilt = binExists ? describe : describe.skip
+
+if (!binExists) {
+	console.warn(`[cli smoke test] Skipped: ${binPath} not built. Run \`pnpm run build-cli\` first.`)
+}
+
+function runCli(args: string[]) {
+	return spawnSync(process.execPath, [binPath, ...args], {
+		encoding: 'utf-8',
+		timeout: 10_000,
+	})
+}
+
+describeIfBuilt('cli binary', () => {
+	it('prints --version matching package.json and exits 0', () => {
+		const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+		const result = runCli(['--version'])
+
+		expect(result.status).toBe(0)
+		expect(result.stderr).toBe('')
+		expect(result.stdout.trim()).toBe(pkg.version)
+	})
+
+	it('prints --help with usage and exits 0', () => {
+		const result = runCli(['--help'])
+
+		expect(result.status).toBe(0)
+		expect(result.stderr).toBe('')
+		expect(result.stdout).toContain('Usage: js-common')
+		expect(result.stdout).toContain('CLI utilities from @rtorcato/js-common')
+	})
+
+	it('runs a subcommand (date today) and exits 0', () => {
+		const result = runCli(['date', 'today'])
+
+		expect(result.status).toBe(0)
+		expect(result.stderr).toBe('')
+		expect(result.stdout.trim()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+	})
+})

--- a/src/tests/example.test.ts
+++ b/src/tests/example.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest'
-
-describe('Example Test', () => {
-	it('should pass', () => {
-		expect(1 + 1).toBe(2)
-	})
-})

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,3 +1,15 @@
-import config from '@rtorcato/js-tooling/vitest/config'
+import { mergeConfig } from 'vitest/config'
+import base from '@rtorcato/js-tooling/vitest/config'
 
-export default config
+export default mergeConfig(base, {
+	test: {
+		coverage: {
+			thresholds: {
+				lines: 85,
+				statements: 85,
+				functions: 95,
+				branches: 70,
+			},
+		},
+	},
+})


### PR DESCRIPTION
## Summary

Tier 3 of the project-assessment cleanup (Tiers 1 and 2 shipped in #41 and #42).

- **CLI smoke test** — `src/cli/cli.test.ts` spawns the built `dist/cli/index.mjs` and asserts `--version`, `--help`, and `date today` each exit 0 with expected output. Closes the gap that let the inquirer / short-uuid regressions slip through.
- **Vitest coverage thresholds** — `vitest.config.mjs` now extends the shared config with explicit per-metric floors:
  - lines: 85 (current 89.8)
  - statements: 85 (current 89.74)
  - functions: 95 (current 97.41)
  - branches: 70 (current 73.79)
  Picked just below today's measured numbers so regressions fail CI without immediate breakage.
- **Lint-staged cleanup** — removed the unused `lint-staged` and `husky.hooks` blocks from `package.json` plus the `lint-staged` devDependency. `.husky/pre-commit` keeps its current full-repo `pnpm typecheck && pnpm check` behaviour; only stale commented lines were trimmed.
- **`src/tests/` removal** — deleted the trivial `example.test.ts` placeholder (`expect(1 + 1).toBe(2)`) and removed the empty directory. It wasn't a fixture used by anything else.

Deferred (not in this PR): inlining `src/math/math.ts` and adding a README coverage badge.

## Test plan

- [x] `pnpm test` — 343/343 passing (3 new CLI smoke tests).
- [x] `pnpm coverage` — passes new thresholds.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm check` — clean (only upstream biome schema-version info notices, unrelated).
- [x] `pnpm run build-cli && node dist/cli/index.mjs --version` — prints `1.8.0`.