### PR TITLE
fix(ci): env-var commit message in check-skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,10 @@ jobs:
         steps:
             - name: Check for skip CI
               id: skip-check
+              env:
+                  COMMIT_MSG: ${{ github.event.head_commit.message }}
               run: |
-                  if [[ "${{ github.event.head_commit.message }}" =~ \[(ci skip|skip ci)\] ]]; then
+                  if [[ "$COMMIT_MSG" =~ \[(ci skip|skip ci)\] ]]; then
                     echo "should-skip=true" >> $GITHUB_OUTPUT
                   else
                     echo "should-skip=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

The `check-skip` job interpolates `github.event.head_commit.message` directly into a bash `[[ ... ]]` expression. When the commit body contains parens, brackets, or backticks (as the squashed PR #47 body did), bash fails with `conditional binary operator expected` and every downstream job — including `release` — is blocked.

Fix: pass the message through an env var so bash sees a quoted string, not a raw script substitution. Also closes a script-injection vector.

After merge, the `release` job will run on `main` and semantic-release will publish the queued **2.0.0** (covering this fix + the unreleased commits from PR #47).

## Test plan

- [x] Workflow YAML syntactically valid (single edit, no structural change)
- [ ] After merge: `check-skip` step completes successfully on `main`
- [ ] After merge: semantic-release publishes 2.0.0 to npm