### PR TITLE
docs: add v1.x to v2.x migration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,30 @@ A comprehensive set of common JavaScript and TypeScript utilities for Node.js pr
 npm install @rtorcato/js-common
 ```
 
+## Migrating from 1.x to 2.x
+
+The only breaking change in 2.0 is a rename in the `errors` module:
+
+```ts
+// 1.x — swallow errors and fall back to a default value
+import { tryCatch } from '@rtorcato/js-common/errors'
+const data = await tryCatch(() => fetchData(), [])
+
+// 2.x — same function, renamed for clarity
+import { tryWithFallback } from '@rtorcato/js-common/errors'
+const data = await tryWithFallback(() => fetchData(), [])
+```
+
+The name `tryCatch` is now reserved for the Result-pattern helper in `@rtorcato/js-common/try`, which returns `{ data, error }` instead of swallowing:
+
+```ts
+import { tryCatch } from '@rtorcato/js-common/try'
+const { data, error } = await tryCatch(() => fetchData())
+if (error) { /* handle */ }
+```
+
+Prefer the Result-style `tryCatch` for new code; reserve `tryWithFallback` for cases where the fallback is genuinely safe.
+
 ## CLI Usage
 
 This package includes a command-line interface for many utilities:


### PR DESCRIPTION
## Summary

Adds a short \`Migrating from 1.x to 2.x\` section to README, between Installation and CLI Usage. Covers the only breaking change in 2.0 — \`tryCatch\` → \`tryWithFallback\` in the errors module — with side-by-side 1.x/2.x snippets, and a note pointing at the Result-style \`tryCatch\` in \`/try\` as the recommended pattern for new code.

Pure docs change. No code, no tests, no dependency changes.

## Test plan

- [x] README renders correctly (Markdown lint via \`pnpm check\` passes)
- [x] No behavior change to verify