### PR TITLE
docs(site): add 2.x migration guide

### DIFF
--- a/apps/doc/astro.config.mjs
+++ b/apps/doc/astro.config.mjs
@@ -33,6 +33,7 @@ export default defineConfig({
 						{ label: 'Introduction', slug: 'index' },
 						{ label: 'Installation', slug: 'guides/installation' },
 						{ label: 'Quick start', slug: 'guides/quick-start' },
+						{ label: 'Migrating to 2.x', slug: 'guides/migration' },
 					],
 				},
 				{

--- a/apps/doc/src/content/docs/guides/migration.md
+++ b/apps/doc/src/content/docs/guides/migration.md
@@ -1,0 +1,28 @@
+---
+title: Migrating to 2.x
+description: Upgrading from 1.x to 2.x.
+---
+
+The only breaking change in 2.0 is a rename in the `errors` module.
+
+## `errors.tryCatch` → `errors.tryWithFallback`
+
+```ts
+// 1.x — swallow errors and fall back to a default value
+import { tryCatch } from '@rtorcato/js-common/errors'
+const data = await tryCatch(() => fetchData(), [])
+
+// 2.x — same function, renamed for clarity
+import { tryWithFallback } from '@rtorcato/js-common/errors'
+const data = await tryWithFallback(() => fetchData(), [])
+```
+
+The name `tryCatch` is now reserved for the Result-pattern helper in `@rtorcato/js-common/try`, which returns `{ data, error }` instead of swallowing:
+
+```ts
+import { tryCatch } from '@rtorcato/js-common/try'
+const { data, error } = await tryCatch(() => fetchData())
+if (error) { /* handle */ }
+```
+
+Prefer the Result-style `tryCatch` for new code; reserve `tryWithFallback` for cases where the fallback is genuinely safe.


### PR DESCRIPTION
## Summary

Adds a Starlight guide page mirroring the README migration section (PR #51):

- New page \`apps/doc/src/content/docs/guides/migration.md\` — covers \`errors.tryCatch\` → \`errors.tryWithFallback\` rename with side-by-side 1.x/2.x snippets and the Result-style \`tryCatch\` recommendation.
- Wired into the "Start here" sidebar in \`apps/doc/astro.config.mjs\` as the last item.

Pure doc-site change. After merge, \`.github/workflows/docs.yml\` auto-deploys to GitHub Pages.

## Test plan

- [x] \`pnpm --filter @rtorcato/js-common-docs build\` — succeeds, 11 pages built
- [x] Pagefind picked up the new page (\`/guides/migration/index.html\`)
- [ ] After merge: GitHub Pages deploy succeeds, page renders at https://rtorcato.github.io/js-common/guides/migration/