### PR TITLE
feat(docs): v2 polish — favicon + button + slug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ coverage/
 # Stitch / design import workspace (regenerated from zip)
 .stitch-import/
 
-# Design handoff bundle (reference material, applied to apps/doc — not shipped)
-design_handoff_docusaurus_redesign/
+# Design handoff bundles (reference material, applied to apps/doc — not shipped)
+design_handoff_docusaurus_redesign*/
+FIX-duplicate-route.md

--- a/apps/doc/docs/index.md
+++ b/apps/doc/docs/index.md
@@ -1,7 +1,6 @@
 ---
 title: js-common
 description: Tree-shakeable TypeScript utilities — tiny bundles, full type safety, CLI included.
-slug: /
 sidebar_position: 0
 ---
 

--- a/apps/doc/src/pages/index.module.css
+++ b/apps/doc/src/pages/index.module.css
@@ -145,9 +145,29 @@
 	font-size: 16px;
 	color: var(--jc-muted);
 }
+/* Self-contained button — no Infima classes, so nothing can override the colors. */
 .viewAll {
+	display: inline-flex;
+	align-items: center;
+	height: 40px;
+	padding: 0 16px;
+	background: transparent;
+	border: 1px solid var(--jc-gold-border);
+	border-radius: 11px;
 	color: var(--jc-gold);
-	border-color: var(--jc-gold-border);
+	font-weight: 600;
+	font-size: 14px;
+	text-decoration: none;
+	transition:
+		background 0.15s,
+		color 0.15s,
+		border-color 0.15s;
+}
+.viewAll:hover {
+	background: var(--jc-gold-fill);
+	border-color: var(--jc-gold-fill);
+	color: var(--jc-on-gold);
+	text-decoration: none;
 }
 
 /* Pillars */

--- a/apps/doc/src/pages/index.tsx
+++ b/apps/doc/src/pages/index.tsx
@@ -176,10 +176,7 @@ function Categories(): ReactElement {
 						Nine focused categories. 46 modules. Import exactly what you need.
 					</p>
 				</div>
-				<Link
-					className={clsx('button button--secondary', styles.viewAll)}
-					to="/docs/modules/overview"
-				>
+				<Link className={styles.viewAll} to="/docs/modules/overview">
 					View all modules →
 				</Link>
 			</div>

--- a/apps/doc/static/img/logo.svg
+++ b/apps/doc/static/img/logo.svg
@@ -1,13 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-	<rect width="64" height="64" rx="12" fill="#25c2a0" />
-	<text
-		x="50%"
-		y="50%"
-		text-anchor="middle"
-		dominant-baseline="central"
-		font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-		font-weight="700"
-		font-size="28"
-		fill="#0d1117"
-	>js</text>
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="js-common">
+  <rect width="32" height="32" rx="8" fill="#F4BA2F"></rect>
+  <path d="M13.2 8.5h2.45v9.04c0 2.83-1.36 4.06-3.66 4.06-1.3 0-2.32-.42-2.99-1.2l1.4-1.55c.36.46.78.76 1.36.76.74 0 1.2-.44 1.2-1.55V8.5h.24z" fill="#0A0E16"></path>
+  <path d="M18.7 19.1c.66.86 1.5 1.45 2.7 1.45.94 0 1.5-.4 1.5-1.04 0-.72-.5-.98-1.55-1.44l-.58-.25c-1.66-.7-2.76-1.58-2.76-3.45 0-1.72 1.31-3.02 3.36-3.02 1.46 0 2.5.5 3.25 1.83l-1.78 1.14c-.39-.7-.8-.97-1.47-.97-.67 0-1.1.43-1.1 1 0 .63.43.89 1.42 1.32l.58.25c1.95.84 3.06 1.69 3.06 3.6 0 2.06-1.62 3.19-3.8 3.19-2.13 0-3.5-1.02-4.18-2.34l1.86-1.08z" fill="#0A0E16"></path>
 </svg>

--- a/biome.json
+++ b/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
   "extends": ["@rtorcato/js-tooling/biome"],
   "files": {
-    "includes": ["!**/.claude", "!**/.stitch-import", "!design_handoff_docusaurus_redesign"]
+    "includes": ["!**/.claude", "!**/.stitch-import", "!design_handoff_docusaurus_redesign*"]
   }
 }


### PR DESCRIPTION
## Summary
Round-2 polish after the dark + gold redesign (PR #62) shipped. Three targeted fixes from the v2 handoff bundle (\`design_handoff_docusaurus_redesign 2/\`):

1. **Favicon**: replaced the green \`{js}\` SVG with a flat gold monogram so browser tabs and link previews stop clashing with the new theme.
2. **\"View all modules →\" button**: dropped Infima's \`.button.button--secondary\` classes (they were silently overriding the gold border/text) and made the link fully self-styled in \`index.module.css\`.
3. **\`docs/index.md\`**: removed the redundant \`slug: /\` frontmatter. With \`routeBasePath: '/docs'\` this was already resolving to \`/docs/\` (no route collision), but removing it makes routing intent explicit and matches the v2 doc.

Also widens the ignore globs so suffixed handoff re-deliveries (\`design_handoff_docusaurus_redesign 2/\`, \`… 3/\`, etc.) stay out of git + Biome automatically.

## Notes
The v2 handoff also proposed adding the gold logo back into the navbar. **Skipped intentionally** — the navbar already uses a custom HTML wordmark (\"js-**common**\" + \`v2.x\` pill) we added in PR #62, which is more distinctive than a logo image.

## Test plan
- [x] \`pnpm typecheck\` (apps/doc) — clean
- [x] \`pnpm build\` (apps/doc) — generates static build
- [x] \`pnpm check\` (root Biome) — 121 files clean
- [ ] After merge: verify \`https://rtorcato.github.io/js-common/\` shows the gold favicon and the gold-bordered \"View all modules\" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)