### PR TITLE
feat(docs): wordmark, icons, install tabs

### DIFF
--- a/apps/doc/docusaurus.config.ts
+++ b/apps/doc/docusaurus.config.ts
@@ -90,7 +90,7 @@ const config: Config = {
 				indexBlog: false,
 				docsRouteBasePath: '/docs',
 				highlightSearchTermsOnTargetPage: true,
-				searchBarShortcutHint: false,
+				searchBarShortcutHint: true,
 			},
 		],
 	],
@@ -101,19 +101,24 @@ const config: Config = {
 			respectPrefersColorScheme: true,
 		},
 		navbar: {
-			title: 'js-common',
-			logo: {
-				alt: 'js-common',
-				src: 'img/logo.svg',
-			},
+			// Text wordmark (gold "common") + v2.x pill is rendered via the HTML
+			// navbar item below — leave title/logo empty so they don't double up.
+			title: '',
 			items: [
+				{
+					type: 'html',
+					position: 'left',
+					value:
+						'<a class="jc-wordmark" href="/js-common/">js-<span class="jc-wordmark-accent">common</span><span class="jc-wordmark-version">v2.x</span></a>',
+				},
 				{ type: 'docSidebar', sidebarId: 'docs', position: 'left', label: 'Docs' },
 				{ to: '/docs/modules/overview', position: 'left', label: 'Modules' },
 				{ to: '/docs/api', position: 'left', label: 'API' },
 				{
 					href: 'https://github.com/rtorcato/js-common',
-					label: 'GitHub',
 					position: 'right',
+					className: 'header-github-link',
+					'aria-label': 'GitHub repository',
 				},
 			],
 		},

--- a/apps/doc/src/css/custom.css
+++ b/apps/doc/src/css/custom.css
@@ -107,6 +107,68 @@
 	color: var(--jc-heading);
 }
 
+/* ---------- Wordmark (HTML navbar item) ---------- */
+.jc-wordmark {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	margin-right: 16px;
+	font-weight: 800;
+	font-size: 18px;
+	letter-spacing: -0.03em;
+	color: var(--jc-heading);
+	text-decoration: none;
+}
+.jc-wordmark:hover {
+	text-decoration: none;
+	color: var(--jc-heading);
+}
+.jc-wordmark-accent {
+	color: var(--jc-gold);
+}
+.jc-wordmark-version {
+	display: inline-flex;
+	align-items: center;
+	height: 20px;
+	padding: 0 7px;
+	background: var(--jc-gold-soft);
+	border: 1px solid var(--jc-gold-border);
+	border-radius: 999px;
+	font: 600 11px var(--ifm-font-family-monospace);
+	color: var(--jc-gold);
+	letter-spacing: 0;
+}
+
+/* ---------- GitHub icon-only link ---------- */
+.header-github-link {
+	width: 32px;
+	height: 32px;
+	padding: 0;
+	margin: 0 4px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--jc-text);
+}
+.header-github-link:hover {
+	color: var(--jc-gold);
+	opacity: 1;
+}
+.header-github-link::before {
+	content: "";
+	width: 22px;
+	height: 22px;
+	background-color: currentColor;
+	-webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.03c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.71 1.26 3.37.97.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.06 11.06 0 0 1 5.79 0c2.21-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.69.41.35.78 1.04.78 2.1v3.11c0 .31.21.66.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z'/></svg>");
+	mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.03c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.71 1.26 3.37.97.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.06 11.06 0 0 1 5.79 0c2.21-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.69.41.35.78 1.04.78 2.1v3.11c0 .31.21.66.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z'/></svg>");
+	-webkit-mask-repeat: no-repeat;
+	mask-repeat: no-repeat;
+	-webkit-mask-position: center;
+	mask-position: center;
+	-webkit-mask-size: contain;
+	mask-size: contain;
+}
+
 /* ---------- Sidebar ---------- */
 .menu {
 	font-size: 14px;

--- a/apps/doc/src/pages/index.module.css
+++ b/apps/doc/src/pages/index.module.css
@@ -71,17 +71,88 @@
 .cta {
 	border-radius: 11px;
 }
+/* Install pill + package-manager tabs */
+.installGroup {
+	display: inline-flex;
+	flex-direction: column;
+	gap: 8px;
+	align-items: flex-start;
+}
+.pmTabs {
+	display: inline-flex;
+	gap: 4px;
+	padding: 4px;
+	background: var(--jc-surface2);
+	border: 1px solid var(--jc-border);
+	border-radius: 8px;
+}
+.pmTab {
+	height: 24px;
+	padding: 0 10px;
+	background: transparent;
+	border: 0;
+	border-radius: 5px;
+	font: 600 12px var(--ifm-font-family-monospace);
+	color: var(--jc-muted);
+	cursor: pointer;
+	transition:
+		background 0.15s,
+		color 0.15s;
+}
+.pmTab:hover {
+	color: var(--jc-text);
+}
+.pmTabActive,
+.pmTabActive:hover {
+	background: var(--jc-gold-soft);
+	color: var(--jc-gold);
+}
 .install {
 	display: inline-flex;
 	align-items: center;
+	gap: 10px;
 	height: 48px;
-	padding: 0 18px;
+	padding: 0 8px 0 16px;
 	background: var(--jc-surface2);
 	border: 1px solid var(--jc-border);
 	border-radius: 11px;
 	font-family: var(--ifm-font-family-monospace);
 	font-size: 13.5px;
 	color: var(--jc-text);
+}
+.installPrompt {
+	color: var(--jc-faint);
+	user-select: none;
+}
+.installCmd {
+	background: transparent;
+	border: 0;
+	padding: 0;
+	color: var(--jc-text);
+	font: inherit;
+}
+.installCopy {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	padding: 0;
+	margin-left: 2px;
+	background: transparent;
+	border: 1px solid var(--jc-border);
+	border-radius: 8px;
+	color: var(--jc-muted);
+	cursor: pointer;
+	transition:
+		color 0.15s,
+		border-color 0.15s,
+		background 0.15s;
+}
+.installCopy:hover {
+	color: var(--jc-gold);
+	border-color: var(--jc-gold-border);
+	background: var(--jc-gold-soft);
 }
 
 /* Code window */
@@ -182,6 +253,22 @@
 	border: 1px solid var(--jc-border);
 	border-radius: 14px;
 }
+.pillarIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	height: 40px;
+	margin-bottom: 14px;
+	background: var(--jc-gold-soft);
+	border: 1px solid var(--jc-gold-border);
+	border-radius: 10px;
+	color: var(--jc-gold);
+}
+.pillarIconSvg {
+	width: 20px;
+	height: 20px;
+}
 .pillarTitle {
 	font-weight: 700;
 	font-size: 15px;
@@ -273,6 +360,12 @@
 	}
 	.heroActions > * {
 		width: 100%;
+		justify-content: center;
+	}
+	.installGroup {
+		align-items: stretch;
+	}
+	.pmTabs {
 		justify-content: center;
 	}
 	.install {

--- a/apps/doc/src/pages/index.tsx
+++ b/apps/doc/src/pages/index.tsx
@@ -2,18 +2,104 @@ import Link from '@docusaurus/Link'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 import Layout from '@theme/Layout'
 import clsx from 'clsx'
-import type { ReactElement } from 'react'
+import { type ReactElement, useEffect, useState } from 'react'
 import styles from './index.module.css'
+
+/* ------------------------------------------------------------------ */
+/* Icons                                                               */
+/* ------------------------------------------------------------------ */
+
+type IconKey = 'gauge' | 'layers' | 'brackets' | 'terminal' | 'copy' | 'check'
+
+type IconProps = {
+	icon: IconKey
+	title: string
+	className?: string
+	size?: number
+}
+
+function Icon({ icon, title, className, size = 22 }: IconProps): ReactElement {
+	return (
+		<svg
+			className={className}
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={1.6}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			role="img"
+		>
+			<title>{title}</title>
+			{ICONS[icon]}
+		</svg>
+	)
+}
+
+const ICONS: Record<IconKey, ReactElement> = {
+	gauge: (
+		<>
+			<path d="M12 14l4-4" />
+			<path d="M3.5 17a9 9 0 0 1 17 0" />
+			<circle cx="12" cy="14" r="1.2" fill="currentColor" />
+		</>
+	),
+	layers: (
+		<>
+			<path d="m12 3 9 5-9 5-9-5z" />
+			<path d="m3 13 9 5 9-5M3 17l9 5 9-5" />
+		</>
+	),
+	brackets: (
+		<>
+			<path d="m9 8-5 4 5 4" />
+			<path d="m15 8 5 4-5 4" />
+		</>
+	),
+	terminal: (
+		<>
+			<rect x="3" y="4" width="18" height="16" rx="2" />
+			<path d="M7 9l3 3-3 3M13 15h4" />
+		</>
+	),
+	copy: (
+		<>
+			<rect x="9" y="9" width="11" height="11" rx="2" />
+			<path d="M5 15V6a2 2 0 0 1 2-2h9" />
+		</>
+	),
+	check: <path d="M5 12l5 5L20 7" />,
+}
 
 /* ------------------------------------------------------------------ */
 /* Data                                                                */
 /* ------------------------------------------------------------------ */
 
-const PILLARS = [
-	{ title: 'Ultra-lightweight', desc: '~277 B core bundle; 50–200 B per module.' },
-	{ title: 'Tree-shakeable', desc: 'Named subpath exports — ship only what you import.' },
-	{ title: 'TypeScript-first', desc: 'Strict types, generics preserved, JSDoc-rich in your IDE.' },
-	{ title: 'CLI included', desc: 'Run utilities from your terminal via npx.' },
+type Pillar = {
+	title: string
+	desc: string
+	icon: IconKey
+}
+
+const PILLARS: Pillar[] = [
+	{ title: 'Ultra-lightweight', desc: '~277 B core bundle; 50–200 B per module.', icon: 'gauge' },
+	{
+		title: 'Tree-shakeable',
+		desc: 'Named subpath exports — ship only what you import.',
+		icon: 'layers',
+	},
+	{
+		title: 'TypeScript-first',
+		desc: 'Strict types, generics preserved, JSDoc-rich in your IDE.',
+		icon: 'brackets',
+	},
+	{
+		title: 'CLI included',
+		desc: 'Run utilities from your terminal via npx.',
+		icon: 'terminal',
+	},
 ]
 
 type Category = {
@@ -80,6 +166,18 @@ const CATEGORIES: Category[] = [
 	},
 ]
 
+const PACKAGE_MANAGERS = ['npm', 'pnpm', 'yarn', 'bun'] as const
+type PackageManager = (typeof PACKAGE_MANAGERS)[number]
+
+const INSTALL_CMDS: Record<PackageManager, string> = {
+	npm: 'npm i @rtorcato/js-common',
+	pnpm: 'pnpm add @rtorcato/js-common',
+	yarn: 'yarn add @rtorcato/js-common',
+	bun: 'bun add @rtorcato/js-common',
+}
+
+const PM_STORAGE_KEY = 'jc-pkg-manager'
+
 const HERO_CODE = `import {
   isEmpty,
   toKebabCase,
@@ -96,6 +194,70 @@ toKebabCase('Hello World')
 /* ------------------------------------------------------------------ */
 /* Sections                                                            */
 /* ------------------------------------------------------------------ */
+
+function InstallPill(): ReactElement {
+	const [pm, setPm] = useState<PackageManager>('npm')
+	const [copied, setCopied] = useState(false)
+
+	useEffect(() => {
+		const stored = window.localStorage.getItem(PM_STORAGE_KEY)
+		if (stored && (PACKAGE_MANAGERS as readonly string[]).includes(stored)) {
+			setPm(stored as PackageManager)
+		}
+	}, [])
+
+	function selectPm(next: PackageManager) {
+		setPm(next)
+		try {
+			window.localStorage.setItem(PM_STORAGE_KEY, next)
+		} catch {
+			// localStorage may be unavailable — ignore.
+		}
+	}
+
+	async function onCopy() {
+		try {
+			await navigator.clipboard.writeText(INSTALL_CMDS[pm])
+			setCopied(true)
+			setTimeout(() => setCopied(false), 1600)
+		} catch {
+			// Clipboard may be unavailable (e.g., insecure context) — ignore.
+		}
+	}
+
+	return (
+		<div className={styles.installGroup}>
+			<div className={styles.pmTabs} role="tablist" aria-label="Package manager">
+				{PACKAGE_MANAGERS.map((name) => (
+					<button
+						key={name}
+						type="button"
+						role="tab"
+						aria-selected={pm === name}
+						className={clsx(styles.pmTab, pm === name && styles.pmTabActive)}
+						onClick={() => selectPm(name)}
+					>
+						{name}
+					</button>
+				))}
+			</div>
+			<div className={styles.install}>
+				<span className={styles.installPrompt} aria-hidden>
+					$
+				</span>
+				<code className={styles.installCmd}>{INSTALL_CMDS[pm]}</code>
+				<button
+					type="button"
+					className={styles.installCopy}
+					onClick={onCopy}
+					aria-label={copied ? 'Copied' : 'Copy install command'}
+				>
+					<Icon icon={copied ? 'check' : 'copy'} title={copied ? 'Copied' : 'Copy'} size={16} />
+				</button>
+			</div>
+		</div>
+	)
+}
 
 function Hero(): ReactElement {
 	const banner = useBaseUrl('/img/banner.png')
@@ -130,7 +292,7 @@ function Hero(): ReactElement {
 					>
 						Get Started →
 					</Link>
-					<code className={styles.install}>npm i @rtorcato/js-common</code>
+					<InstallPill />
 				</div>
 			</div>
 		</header>
@@ -157,6 +319,9 @@ function Pillars(): ReactElement {
 			<div className={styles.pillarGrid}>
 				{PILLARS.map((p) => (
 					<div key={p.title} className={styles.pillar}>
+						<div className={styles.pillarIcon}>
+							<Icon icon={p.icon} title={p.title} size={20} className={styles.pillarIconSvg} />
+						</div>
 						<div className={styles.pillarTitle}>{p.title}</div>
 						<div className={styles.pillarDesc}>{p.desc}</div>
 					</div>


### PR DESCRIPTION
## Summary
Two things:

1. **Restore polish** that was lost when PR #62 squash-merged with only its first commit (the navbar wordmark, GitHub icon, pillar icons, and search shortcut hint never landed).
2. **New: package-manager tabs** on the hero install pill — npm / pnpm / yarn / bun, with the choice persisted in localStorage.

### Navbar
- Custom HTML wordmark item: \"js-**common**\" with gold \"common\" + a \`v2.x\` pill (replaces the default Docusaurus logo + plain title).
- GitHub link is icon-only (CSS-masked SVG).
- Search bar shows the kbd shortcut hint (⌘K).

### Hero install pill
- Tabs to switch between **npm**, **pnpm**, **yarn**, **bun**.
- Selection persisted in \`localStorage\` under \`jc-pkg-manager\`.
- \`\$\` prompt on the left, copy-to-clipboard button on the right (checkmark feedback on success).

### Pillars
- Each card gains a gold-tinted icon tile (gauge / layers / brackets / terminal) above the title.

## Why this PR exists
PR #62 was squashed with only commit \`b703915\` (the baseline drop-in). The follow-up polish commit \`48dd157\` (wordmark / icons / install pill / GitHub icon / search hint) never made it into the squash. This PR puts it back, plus adds the package-manager tabs the live design was missing.

## Test plan
- [x] \`pnpm typecheck\` (apps/doc) — clean
- [x] \`pnpm build\` (apps/doc) — generates static build
- [x] \`pnpm check\` (root Biome) — 121 files clean
- [ ] After merge, verify on https://rtorcato.github.io/js-common/:
  - Wordmark + v2.x pill in navbar
  - GitHub icon (not text) in top-right
  - Search bar shows ⌘K hint
  - 4 pillar cards each have a gold icon
  - Install pill: clicking a PM tab swaps the command; copy button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)