### PR TITLE
ci: use RELEASE_TOKEN PAT for releases on protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
             - name: 📦 Setup Node.js
               uses: actions/setup-node@v6
@@ -297,7 +297,7 @@ jobs:
 
             - name: 🚀 Run semantic-release
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: npx semantic-release


### PR DESCRIPTION
Switches the release job to `${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` so semantic-release can push the version commit + tag to a protected `main`. `GITHUB_TOKEN` alone cannot bypass branch protection. Falls back to `GITHUB_TOKEN` when no PAT is set, so nothing changes on unprotected repos.

RELEASE_TOKEN (admin PAT) is already configured as a repo secret.