### PR TITLE
docs: add badges to docs landing page

### DIFF
--- a/apps/doc/docs/index.mdx
+++ b/apps/doc/docs/index.mdx
@@ -8,6 +8,12 @@ import InstallTabs from '@site/src/components/InstallTabs'
 
 # js-common
 
+[![CI](https://github.com/rtorcato/js-common/actions/workflows/ci.yml/badge.svg)](https://github.com/rtorcato/js-common/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/@rtorcato/js-common.svg)](https://www.npmjs.com/package/@rtorcato/js-common)
+[![npm downloads](https://img.shields.io/npm/dm/@rtorcato/js-common.svg)](https://www.npmjs.com/package/@rtorcato/js-common)
+[![Bundle size](https://img.shields.io/bundlephobia/minzip/@rtorcato/js-common)](https://bundlephobia.com/package/@rtorcato/js-common)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A focused set of TypeScript utilities for the everyday JavaScript/Node.js work almost every project repeats — date math, string formatting, array/object helpers, validation, UUIDs, retries, sleeps, currency, and so on. Each module ships as a separate subpath so your bundler only includes what you actually import.
 
 - **Ultra-lightweight** — main bundle ~277 B; individual modules ~50–200 B.


### PR DESCRIPTION
Adds a badge row to the docs site landing page (docs index) so the Docusaurus site carries badges like js-tooling.

Full row (CI · npm version · downloads · bundle size · License) for `@rtorcato/js-common`.

Part of adding badges to every `@rtorcato/*-common` repo's docs index page (see rtorcato/api-common#122 for the same change there).