### PR TITLE
fix(release): upgrade npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,9 +295,11 @@ jobs:
             - name: 🏗️ Build for release
               run: pnpm run build-prod
 
+            # OIDC trusted publishing needs npm CLI >= 11.5.1; the runner ships 10.x.
+            - name: 📦 Upgrade npm for OIDC trusted publishing
+              run: npm install -g npm@latest
+
             - name: 🚀 Run semantic-release
               env:
                   GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: npx semantic-release


### PR DESCRIPTION
## Problem

Publishing fails with `ENEEDAUTH` on the runner's bundled npm 10.x. After
semantic-release performs its OIDC token exchange, npm 10.x doesn't understand
the exchanged credentials and falls back to looking for an auth token that no
longer exists.

## Root cause

npm OIDC trusted publishing requires **npm CLI >= 11.5.1**, but the GitHub
Actions runner ships npm 10.x.

## Fix

- Drop `NPM_TOKEN` / `NODE_AUTH_TOKEN` from the release step (keep `GITHUB_TOKEN`).
- Add a step to upgrade npm (`npm install -g npm@latest`) before publishing.

Proven on `rtorcato/js-tooling` and `api-common`.

## Before merge

Configure a **Trusted Publisher** on npmjs.com for `@rtorcato/js-common`:

- Provider: GitHub Actions
- Owner: `rtorcato`
- Repository: `js-common`
- Workflow: `ci.yml`
- Permission: allow `npm publish`