### PR TITLE
fix(release): upgrade npm for OIDC publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,9 +295,11 @@ jobs:
             - name: 🏗️ Build for release
               run: pnpm run build-prod
 
+            # OIDC trusted publishing needs npm CLI >= 11.5.1; the runner ships 10.x.
+            - name: 📦 Upgrade npm for OIDC trusted publishing
+              run: npm install -g npm@latest
+
             - name: 🚀 Run semantic-release
               env:
                   GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: npx semantic-release


### PR DESCRIPTION
Replaces #110 (same change, shorter commit header to satisfy this repo's 50-char commitlint rule).

semantic-release's OIDC token exchange succeeds but the `npm publish` it shells out to fails with ENEEDAUTH on npm 10.x — OIDC trusted publishing needs npm >= 11.5.1. Drops `NPM_TOKEN`/`NODE_AUTH_TOKEN` and adds `npm install -g npm@latest` before semantic-release (proven on js-tooling/api-common). Trusted publisher for @rtorcato/js-common is already configured (ci.yml).