### PR TITLE
chore(types): remove dead commented api re-export

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,3 +1,2 @@
 export * from './common'
-// export * from './api'
 export * from './env'


### PR DESCRIPTION
Removes the orphaned `// export * from './api'` comment in `src/types/index.d.ts` — there is no `./api` module, so the line is just noise (YAGNI: re-export it if/when the module is ever added).

Closes #75