### PR TITLE
docs(readme): add CI, downloads, size badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ![js-common banner](./banner.png)
 
+[![CI](https://github.com/rtorcato/js-common/actions/workflows/ci.yml/badge.svg)](https://github.com/rtorcato/js-common/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/%40rtorcato%2Fjs-common.svg)](https://badge.fury.io/js/%40rtorcato%2Fjs-common)
+[![npm downloads](https://img.shields.io/npm/dm/@rtorcato/js-common.svg)](https://www.npmjs.com/package/@rtorcato/js-common)
+[![Bundle size](https://img.shields.io/bundlephobia/minzip/@rtorcato/js-common)](https://bundlephobia.com/package/@rtorcato/js-common)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D22.0.0-brightgreen.svg)](https://nodejs.org/)


### PR DESCRIPTION
Rounds out the README badge row to match js-tooling: adds **CI status**, **npm monthly downloads**, and **bundlephobia minzip size**. Keeps the existing npm-version, codecov, and license badges. All three resolve without any setup.

Closes #98