### PR TITLE
chore: pin pnpm via packageManager field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,6 @@ jobs:
 
             - name: 📦 Setup pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: 📦 Generate cache key
               id: cache-key
@@ -86,8 +84,6 @@ jobs:
 
             - name: 📦 Setup pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: 📦 Restore dependencies cache
               uses: actions/cache@v5
@@ -117,8 +113,6 @@ jobs:
 
             - name: 📦 Setup pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: 📦 Restore dependencies cache
               uses: actions/cache@v5
@@ -146,8 +140,6 @@ jobs:
 
             - name: 📦 Setup pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: 📦 Restore dependencies cache
               uses: actions/cache@v5
@@ -174,8 +166,6 @@ jobs:
 
             - name: 📦 Setup pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: 📦 Setup Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v6
@@ -204,8 +194,6 @@ jobs:
 
             - name: 📦 Setup pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: 📦 Restore dependencies cache
               uses: actions/cache@v5
@@ -243,8 +231,6 @@ jobs:
 
             - name: 📦 Setup pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: 📦 Restore dependencies cache
               uses: actions/cache@v5
@@ -276,8 +262,6 @@ jobs:
 
             - name: 📦 Setup pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: 📦 Restore dependencies cache
               uses: actions/cache@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,8 +27,6 @@ jobs:
 
             - name: 📦 Setup pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: 📦 Setup Node.js
               uses: actions/setup-node@v6

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -79,8 +77,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -141,8 +137,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,8 +41,6 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v6
-              with:
-                  version: latest
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.8.2",
   "description": "JavaScript and TypeScript common code",
   "type": "module",
+  "packageManager": "pnpm@10.34.5",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.8.2",
   "description": "JavaScript and TypeScript common code",
   "type": "module",
-  "packageManager": "pnpm@10.34.5",
+  "packageManager": "pnpm@11.17.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Why

CI's `pnpm/action-setup@v6` steps used `version: latest`. When that resolves to a newer pnpm than the one that generated `pnpm-lock.yaml`, any lockfile-touching PR gets a peer-format rewrite plus incidental dep bumps (seen on #114, which needed regenerating with pnpm 10 to stay clean).

## Change

- Pin `packageManager: pnpm@10.34.5` in `package.json` (matches the current lockfile format — zero churn).
- Remove `version: latest` from all 13 `pnpm/action-setup@v6` steps across `ci.yml`, `docs.yml`, `security.yml`, `performance.yml`, so action-setup reads the pinned version from `package.json`.

Bumping to pnpm 11 later becomes a deliberate one-line change instead of silent drift.