### PR TITLE
chore(deps): hold TypeScript at 6.x until typedoc supports 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
   commit-message:
     prefix: "chore"
     include: "scope"
+  # typedoc peers cap at TypeScript 6.0.x, so TS 7 breaks the docs API
+  # reference build. Drop this once typedoc 1.0 ships with TS 7 support.
+  ignore:
+  - dependency-name: "typescript"
+    update-types: ["version-update:semver-major"]
   # Group updates to reduce PR noise
   groups:
     development-dependencies:


### PR DESCRIPTION
## Problem

Dependabot's `development-dependencies` group keeps proposing `typescript` 7.x
(#88 → #133). It fails `docs-build`:

```
[cause]: TypeError: Cannot read properties of undefined (reading 'PropertyDeclaration')
    at typedoc@0.28.19_typescript@7.0.2/.../converter/comments/discovery.js:9:19
```

typedoc 0.28.20 is the latest stable and peers on
`5.0.x || 5.1.x || ... || 5.9.x || 6.0.x` — TypeScript 7 is not supported yet
(only `1.0.0-dev.*` prereleases exist beyond 0.28.x).

## Fix

Ignore major `typescript` bumps in `.github/dependabot.yml`, so the rest of the
dev-dependency group (e.g. `@types/node`) can still land on its own.

Remove the ignore once typedoc 1.0 ships with TS 7 support.