### PR TITLE
chore(deps): cap TypeScript at <7 by version, not by update-type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
   # reference build. Drop this once typedoc 1.0 ships with TS 7 support.
   ignore:
   - dependency-name: "typescript"
-    update-types: ["version-update:semver-major"]
+    versions: [">=7"]
   # Group updates to reduce PR noise
   groups:
     development-dependencies:


### PR DESCRIPTION
Follow-up to #134.

`update-types: ["version-update:semver-major"]` was the wrong knob. Because
`apps/docs` pins `typescript: ~5.6.3` and the root pins `^6.0.2`, Dependabot
resolved the group to the highest non-major version *relative to apps/docs* —
so #136 proposed **downgrading** the root from `^6.0.2` to `^5.9.3`.

`versions: [">=7"]` expresses the real constraint (typedoc 0.28.20 peers on
`5.0.x || ... || 6.0.x`) and still lets 6.x updates through.

Closes #136 in favour of a regenerated group PR.