### PR TITLE
docs: surface migration guide from homepage hero

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ Index of open work for `@rtorcato/js-common`. Each row links to a GitHub issue �
 - [ ] [#84](https://github.com/rtorcato/js-common/issues/84) — "See also" cross-links between related modules
 - [ ] [#85](https://github.com/rtorcato/js-common/issues/85) — Recipes / cookbook section (task-oriented pages composing multiple modules)
 - [ ] [#86](https://github.com/rtorcato/js-common/issues/86) — OG/social card images, custom 404, `og:image` metadata
-- [ ] [#87](https://github.com/rtorcato/js-common/issues/87) — Surface migration page from homepage hero
+- [x] [#87](https://github.com/rtorcato/js-common/issues/87) — Surface migration page from homepage hero
 - [ ] [#74](https://github.com/rtorcato/js-common/issues/74) — README references undefined export `validateEmail`
 - [ ] [#77](https://github.com/rtorcato/js-common/issues/77) — Add "Related packages" section linking browser-common and js-tooling to README
 - [ ] [#72](https://github.com/rtorcato/js-common/issues/72) — Cross-link sibling repos (browser-common, js-tooling, swift-common) from docs

--- a/apps/docs/src/pages/index.module.css
+++ b/apps/docs/src/pages/index.module.css
@@ -87,6 +87,43 @@
 	color: var(--jc-heading);
 }
 
+/* Migration callout */
+.migration {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 8px 8px 16px;
+	background: var(--jc-gold-soft);
+	border: 1px solid var(--jc-gold-border);
+	border-radius: 14px;
+	font-size: 14px;
+	color: var(--jc-text);
+}
+.migration a {
+	color: var(--jc-gold);
+	font-weight: 600;
+}
+.migrationDismiss {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: none;
+	width: 26px;
+	height: 26px;
+	padding: 0;
+	background: transparent;
+	border: 0;
+	border-radius: 8px;
+	color: var(--jc-muted);
+	font-size: 18px;
+	line-height: 1;
+	cursor: pointer;
+}
+.migrationDismiss:hover {
+	background: var(--jc-surface);
+	color: var(--jc-heading);
+}
+
 /* Code window */
 .codeWindow {
 	border-radius: 14px;

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -2,7 +2,7 @@ import Link from '@docusaurus/Link'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 import Layout from '@theme/Layout'
 import clsx from 'clsx'
-import type { ReactElement } from 'react'
+import { type ReactElement, useEffect, useState } from 'react'
 import InstallTabs from '@site/src/components/InstallTabs'
 import styles from './index.module.css'
 
@@ -221,9 +221,51 @@ function Hero(): ReactElement {
 						</Link>
 					</div>
 					<InstallTabs pkg="@rtorcato/js-common" />
+					<MigrationCallout />
 				</div>
 			</div>
 		</header>
+	)
+}
+
+const MIGRATION_DISMISSED = 'jc-migration-callout-dismissed'
+
+function MigrationCallout(): ReactElement | null {
+	// Starts hidden: localStorage doesn't exist during the prerender, and reading it
+	// in an effect means people who dismissed it never see a flash of the callout.
+	const [visible, setVisible] = useState(false)
+	useEffect(() => {
+		try {
+			setVisible(localStorage.getItem(MIGRATION_DISMISSED) !== '1')
+		} catch {
+			// Storage blocked (e.g. all cookies disabled) — show it, just don't persist.
+			setVisible(true)
+		}
+	}, [])
+
+	if (!visible) return null
+
+	return (
+		<div className={styles.migration}>
+			<span>
+				Coming from 1.x? <Link to="/docs/guides/migration">Read the migration guide</Link>.
+			</span>
+			<button
+				type="button"
+				className={styles.migrationDismiss}
+				aria-label="Dismiss migration guide notice"
+				onClick={() => {
+					setVisible(false)
+					try {
+						localStorage.setItem(MIGRATION_DISMISSED, '1')
+					} catch {
+						// Storage blocked — dismissal just won't persist across reloads.
+					}
+				}}
+			>
+				×
+			</button>
+		</div>
 	)
 }
 


### PR DESCRIPTION
Closes #87

Adds a dismissable callout to the homepage hero, below the install tabs, pointing readers arriving from 1.x at `/docs/guides/migration` — the guide existed but was buried in the sidebar.

## Implementation notes

- **SSR-safe.** Docusaurus prerenders this page, so `localStorage` is read inside a `useEffect`, never during render. The callout starts hidden and appears after hydration, so anyone who already dismissed it never sees a flash of it.
- Storage access is wrapped in `try`/`catch` — if cookies/storage are blocked the callout still shows, it just won't remember the dismissal.
- Styled with the existing `--jc-*` token vocabulary (`--jc-gold-soft`, `--jc-gold-border`, `--jc-muted`), all of which are defined for both `:root` and `[data-theme="dark"]`. No new hex values.
- Dismiss button is icon-only, so it carries `aria-label="Dismiss migration guide notice"`.

## Verification

- `pnpm --filter ./apps/docs build` passes — this is the real SSR check.
- `pnpm typecheck` passes.
- Rendered and checked in **both** themes: dark shows a gold-bordered pill with a gold link; light shows a cream fill with `#9a6f00` link text. The `×` centres in its 26px box with no clipping, and spacing inherits the existing 22px `heroActions` gap.
- Link resolves with baseUrl: `/js-common/docs/guides/migration`.
- Dismiss → element leaves the DOM and the key persists; reload keeps it dismissed; clearing the key brings it back.

Ticks the #87 row in `TODO.md`.