### PR TITLE
fix(docs): render code blocks on a light surface in light mode

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -190,7 +190,7 @@ const config: Config = {
 			copyright: `Copyright © ${new Date().getFullYear()} Richard Torcato. Built with Docusaurus.`,
 		},
 		prism: {
-			theme: prismThemes.vsDark,
+			theme: prismThemes.github,
 			darkTheme: prismThemes.vsDark,
 			additionalLanguages: ['bash', 'json', 'typescript'],
 		},

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -285,34 +285,36 @@ body,
 }
 
 /* ---------- Code ----------
-   Prism is vsDark in both light & dark mode (to match the navy aesthetic),
-   so fenced code blocks must stay dark in BOTH themes — otherwise the pale
-   vsDark tokens wash out on a light background. Inline code (the `code` pills)
-   keeps the themed --ifm-code-background and stays readable. */
+   Prism follows the theme: `theme` (the light slot) is github, `darkTheme` is
+   vsDark — see docusaurus.config.ts. The surface follows with it via the themed
+   tokens, so the block is light-grey on the white page and navy in dark mode.
+   The !important beats prism-react-renderer's inline `plain` style on <pre>,
+   which no selector can outrank. Inline code (the `code` pills) keeps the
+   themed --ifm-code-background and is untouched here. */
 .theme-code-block,
 div[class*="codeBlockContainer"],
 pre[class*="language-"] {
 	border: 1px solid var(--jc-border);
 	border-radius: 12px;
-	background: #0c111b !important;
+	background: var(--jc-code-bg) !important;
 }
 .theme-code-block code,
 pre[class*="language-"] code {
 	background: transparent !important;
-	color: #dfe5ee;
+	color: var(--jc-text);
 }
 /* code block toolbar/title bar (when a title is set) */
 div[class*="codeBlockTitle"] {
-	background: #0a0e16 !important;
-	color: #94a1b4 !important;
+	background: var(--jc-bg2) !important;
+	color: var(--jc-muted) !important;
 	border-bottom: 1px solid var(--jc-border);
 }
-/* in light mode give the dark block a touch more separation from the white page */
+/* light mode: the block sits on white, so it needs the stronger border to read
+   as a distinct surface */
 [data-theme="light"] .theme-code-block,
 [data-theme="light"] div[class*="codeBlockContainer"],
 [data-theme="light"] pre[class*="language-"] {
-	border-color: rgba(12, 18, 28, 0.16);
-	box-shadow: 0 8px 24px -18px rgba(12, 18, 28, 0.5);
+	border-color: var(--jc-border2);
 }
 code {
 	font-family: var(--ifm-font-family-monospace);


### PR DESCRIPTION
Closes #126

In light mode every fenced code block rendered on the dark navy background, putting a black slab in the middle of a white page.

Two things caused it and both had to move together — flipping either alone leaves it broken:

1. `prism.theme` (which is the **light**-mode slot; `prism.darkTheme` is the dark one) was set to `vsDark`.
2. `custom.css` then pinned `background: #0c111b !important` unconditionally to compensate, so the config alone could never win.

## The fix

`prism.theme` → `prismThemes.github`, and the three hardcoded surfaces now route through tokens that already carry correct light **and** dark values:

| | before | after |
|---|---|---|
| block background | `#0c111b !important` | `var(--jc-code-bg)` |
| code text | `#dfe5ee` | `var(--jc-text)` |
| title bar | `#0a0e16` / `#94a1b4` | `var(--jc-bg2)` / `var(--jc-muted)` |

No `[data-theme]` scoping was needed — the tokens already branch. **The dark values are the same hex that was hardcoded**, so dark mode is unchanged and only light mode changes behaviour.

Also removed the compensating light-mode `box-shadow`, and rewrote the comment above the block, which asserted the now-false rationale ("fenced code blocks must stay dark in BOTH themes").

The one remaining `!important` beats prism-react-renderer's inline `plain` style on `<pre>`, which no selector can outrank.

## Verification

`pnpm --filter ./apps/docs build` passes. Computed styles read off the served build in both themes:

**Light** — block `rgb(243,246,249)` (`#f3f6f9`), code text `#374253`, `import` keyword `#00009f`, title bar `#f6f8fb` on `#5b6675`, highlighted line `rgba(244,186,47,.14)`, inline pill `#f3f6f9`. Readable throughout.

**Dark** — block `rgb(12,17,27)` (`#0c111b`, identical to before), code text `#dfe5ee` (identical), `import` keyword `#569cd6` (vsDark), highlighted line `rgba(244,186,47,.12)`, inline pill `rgba(255,255,255,.1)` (untouched).

One cosmetic note for review: in light mode the title bar (`#f6f8fb`) and block body (`#f3f6f9`) are nearly the same value, so the two are separated by the `border-bottom` alone. Legible, but if you want a more distinct title bar that is a follow-up.

## ⚠️ This file is a copy — the fix must go upstream too

`custom.css` header says:

> Consumes the shared @rtorcato base tokens (Geist font + navy surfaces) from repo-tooling via `_jt-tokens.css` — the canonical source these `--jt-*` tokens were extracted from (refresh with `repo-tooling copy docusaurus-theme-tokens`).

The root fix is rtorcato/repo-tooling#324. **The next `repo-tooling copy docusaurus-theme-tokens` will silently revert this** unless repo-tooling's `tooling/docusaurus/theme.css` carries the same change first. Per the issue, ten family docs sites have the identical pair.