### PR TITLE
test: add type tests for functions and promises helpers

### DIFF
--- a/src/functions/functions.test-d.ts
+++ b/src/functions/functions.test-d.ts
@@ -1,0 +1,43 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { debounce, once, throttle } from './index'
+
+describe('functions — types', () => {
+	it('once preserves the wrapped function signature', () => {
+		const load = (id: number, label: string) => ({ id, label })
+		const wrapped = once(load)
+		expectTypeOf(wrapped).toEqualTypeOf<typeof load>()
+		expectTypeOf(wrapped).parameters.toEqualTypeOf<[number, string]>()
+		expectTypeOf(wrapped).returns.toEqualTypeOf<{ id: number; label: string }>()
+		// @ts-expect-error — arguments are still checked
+		wrapped('1', 'a')
+	})
+
+	it('debounce preserves the wrapped function parameters', () => {
+		const fn = (_a: string, _b: number) => {}
+		const debounced = debounce(fn, 100)
+		expectTypeOf(debounced).toEqualTypeOf<typeof fn>()
+		expectTypeOf(debounced).parameters.toEqualTypeOf<[string, number]>()
+		expectTypeOf(debounced).returns.toEqualTypeOf<void>()
+		// @ts-expect-error — arguments are still checked
+		debounced(1, 'a')
+	})
+
+	it('throttle preserves the wrapped function parameters', () => {
+		const fn = (_event: { x: number }) => {}
+		const throttled = throttle(fn, 100)
+		expectTypeOf(throttled).toEqualTypeOf<typeof fn>()
+		expectTypeOf(throttled).parameters.toEqualTypeOf<[{ x: number }]>()
+		expectTypeOf(throttled).returns.toEqualTypeOf<void>()
+		// @ts-expect-error — arguments are still checked
+		throttled({ y: 1 })
+	})
+
+	it('debounce/throttle keep a non-void return type even though the wrapper drops it', () => {
+		// Current (unsound) behaviour: the `=> void` constraint accepts value-returning
+		// functions, so `T` — and therefore the returned type — still says `number`,
+		// while at runtime the wrapper returns undefined. Asserted as-is, not endorsed.
+		const fn = (n: number) => n * 2
+		expectTypeOf(debounce(fn, 10)).returns.toEqualTypeOf<number>()
+		expectTypeOf(throttle(fn, 10)).returns.toEqualTypeOf<number>()
+	})
+})

--- a/src/promises/promises.test-d.ts
+++ b/src/promises/promises.test-d.ts
@@ -1,0 +1,24 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { all, allSettled, race, to, withTimeout } from './index'
+
+describe('promises — types', () => {
+	it('withTimeout preserves the awaited type', () => {
+		expectTypeOf(withTimeout(Promise.resolve(42), 10)).toEqualTypeOf<Promise<number>>()
+		expectTypeOf(withTimeout(Promise.resolve({ id: 1 }), 10)).toEqualTypeOf<
+			Promise<{ id: number }>
+		>()
+	})
+
+	it('to returns an [error, value] tuple with the value widened to undefined', () => {
+		// The error slot is `any` — see the note in the issue thread, not fixed here.
+		expectTypeOf(to(Promise.resolve('x'))).toEqualTypeOf<Promise<[any, string | undefined]>>()
+	})
+
+	it('all/allSettled/race preserve the element type', () => {
+		expectTypeOf(all([Promise.resolve(1)])).toEqualTypeOf<Promise<number[]>>()
+		expectTypeOf(allSettled([Promise.resolve('a')])).toEqualTypeOf<
+			Promise<PromiseSettledResult<string>[]>
+		>()
+		expectTypeOf(race([Promise.resolve(true)])).toEqualTypeOf<Promise<boolean>>()
+	})
+})


### PR DESCRIPTION
Closes #76

Generic helpers lose inference silently — TS still compiles and the runtime tests still pass while the call site quietly widens. These lock the signatures down.

- **functions**: `once`, `debounce`, `throttle` — preserve parameters and return type
- **promises**: `withTimeout`, `to`, `all`, `allSettled`, `race` — preserve the awaited type

## The issue's task list is partly stale

Checked each item against source before writing anything:

| Issue item | Reality |
|---|---|
| `objects/pick`, `objects/omit` | already covered, `objects.test-d.ts:5-19` |
| `objects/groupBy` | lives in `arrays`, not `objects` — already covered in `arrays.test-d.ts:21-25` |
| `promises/retry` | **does not exist in `src/`** |
| `promises/timeout` | the real export is `withTimeout` |

So `objects.test-d.ts` needed no changes, and the genuinely new coverage is `functions` and `promises`.

## How these are enforced

Worth stating explicitly, because it is not obvious. `*.test-d.ts` files do **not** run under `pnpm test` — vitest has no `test.typecheck` block configured, so the runner skips them. They are enforced by `tsc --noEmit` instead: `tsconfig.json:11-21` includes `src/**/*` and excludes `**/*.spec.ts` / `**/*.test.ts` but **not** `**/*.test-d.ts`. CI runs `pnpm typecheck` as its own job (`ci.yml:128`, which `release` depends on), and Husky runs it pre-commit.

Verified by deliberately breaking an assertion — `withTimeout(Promise.resolve(42), 10)` asserted as `Promise<string>`:

```
$ pnpm typecheck
src/promises/promises.test-d.ts(6,68): error TS2344: Type 'Promise<string>' does not satisfy the constraint …
exit 2
```

Then reverted. So these files fail the build when wrong; they just report as a raw `TS2344` on an expect-type branded type rather than a named test. Wiring `test.typecheck` so the runner names them is a DX improvement, deliberately left out of this PR.

## Two pre-existing weaknesses asserted as-is, not fixed

Both filed as #144. The tests encode **current** behaviour with a comment saying so — flip them when #144 lands:

1. `debounce`/`throttle` constrain `T extends (...args: any[]) => void` and return `T`. TS's return-type-void rule lets a value-returning function satisfy that, so the declared return type outlives the wrapper's actual `undefined`.
2. `to()` types its error slot as `any`.

## Verification

`pnpm typecheck` clean · `pnpm exec biome check src` clean · `pnpm test --run` 49 passed / 368 tests, unchanged (these files add no runtime tests) · `pnpm exec vitest --typecheck --run` picks up both new files, `Type Errors no errors`.