### PR TITLE
test: add fast-check property tests for objects, promises and json

### DIFF
--- a/src/json/json.prop.test.ts
+++ b/src/json/json.prop.test.ts
@@ -1,0 +1,62 @@
+import * as fc from 'fast-check'
+import { describe, expect, it } from 'vitest'
+import { isValidJson, safeJsonParse, safeJsonStringify } from './index'
+
+// Keys are capped at 6 chars so `__proto__`/`constructor` can never be generated.
+const key = fc.string({ minLength: 1, maxLength: 6 })
+
+// Deliberately no doubles: `-0` stringifies to `"0"`, which is a JSON round-trip
+// limitation rather than anything this module controls.
+const jsonValue = fc.letrec<{ leaf: unknown; node: unknown }>((tie) => ({
+	leaf: fc.oneof(fc.integer(), fc.string(), fc.boolean(), fc.constant(null)),
+	node: fc.oneof(
+		{ maxDepth: 3 },
+		tie('leaf'),
+		fc.array(tie('node'), { maxLength: 4 }),
+		fc.dictionary(key, tie('node'), { maxKeys: 4, noNullPrototype: true })
+	),
+})).node
+
+describe('json — properties', () => {
+	it('safeJsonStringify round-trips through safeJsonParse', () => {
+		fc.assert(
+			fc.property(jsonValue, (value) => {
+				expect(safeJsonParse(safeJsonStringify(value) as string)).toEqual(value)
+			})
+		)
+	})
+
+	it('safeJsonStringify always emits valid JSON', () => {
+		fc.assert(
+			fc.property(jsonValue, (value) => {
+				expect(isValidJson(safeJsonStringify(value) as string)).toBe(true)
+			})
+		)
+	})
+
+	it('safeJsonStringify returns the fallback on circular references instead of throwing', () => {
+		fc.assert(
+			fc.property(
+				fc.dictionary(key, jsonValue, { maxKeys: 4, noNullPrototype: true }),
+				fc.string(),
+				(obj, fallback) => {
+					const circular: Record<string, unknown> = { ...obj }
+					circular['self'] = circular
+					expect(safeJsonStringify(circular, fallback)).toBe(fallback)
+					expect(safeJsonStringify(circular)).toBeNull()
+				}
+			)
+		)
+	})
+
+	it('safeJsonParse never throws — it falls back exactly when the input is not JSON', () => {
+		const sentinel = { fallback: true }
+		fc.assert(
+			fc.property(fc.string(), (str) => {
+				const parsed = safeJsonParse<unknown>(str, sentinel)
+				if (isValidJson(str)) expect(parsed).toEqual(JSON.parse(str))
+				else expect(parsed).toBe(sentinel)
+			})
+		)
+	})
+})

--- a/src/numbers/numbers.prop.test.ts
+++ b/src/numbers/numbers.prop.test.ts
@@ -1,6 +1,11 @@
 import * as fc from 'fast-check'
 import { describe, expect, it } from 'vitest'
-import { between, clamp, max, min, sum } from './index'
+import { between, clamp, max, min, roundTo, sum } from './index'
+
+// `roundTo` is `Math.round(value * 10**decimals) / 10**decimals`, so the magnitude
+// is capped where the multiply/divide round trip stays exact.
+const roundable = fc.double({ min: -1e6, max: 1e6, noNaN: true, noDefaultInfinity: true })
+const decimals = fc.integer({ min: 0, max: 6 })
 
 describe('numbers — properties', () => {
 	it('clamp result is always inside [min, max]', () => {
@@ -58,6 +63,23 @@ describe('numbers — properties', () => {
 				const hi = Math.max(a, b)
 				const inside = clamp(value, lo, hi)
 				expect(between(inside, lo, hi)).toBe(true)
+			})
+		)
+	})
+
+	it('roundTo is idempotent', () => {
+		fc.assert(
+			fc.property(roundable, decimals, (value, places) => {
+				const once = roundTo(value, places)
+				expect(roundTo(once, places)).toBe(once)
+			})
+		)
+	})
+
+	it('roundTo never moves a value by more than half a step', () => {
+		fc.assert(
+			fc.property(roundable, decimals, (value, places) => {
+				expect(Math.abs(roundTo(value, places) - value)).toBeLessThanOrEqual(0.5 / 10 ** places)
 			})
 		)
 	})

--- a/src/objects/objects.prop.test.ts
+++ b/src/objects/objects.prop.test.ts
@@ -1,0 +1,139 @@
+import * as fc from 'fast-check'
+import { describe, expect, it } from 'vitest'
+import { deepClone, deepMerge, isPlainObject } from './index'
+
+// Biased towards a tiny pool so two generated objects actually collide on keys —
+// with purely random keys the merge properties are vacuously true. Capped at 6
+// chars so `__proto__`/`constructor` can never be generated.
+const key = fc.oneof(
+	{ arbitrary: fc.constantFrom('a', 'b', 'c', 'nest'), weight: 4 },
+	{ arbitrary: fc.string({ minLength: 1, maxLength: 6 }), weight: 1 }
+)
+
+// Constrained to what `structuredClone` actually supports: no functions, no
+// symbols, no null-prototype objects, no sparse arrays.
+const cloneable = fc.letrec<{ leaf: unknown; node: unknown }>((tie) => ({
+	leaf: fc.oneof(
+		fc.integer(),
+		fc.string(),
+		fc.boolean(),
+		fc.bigInt(),
+		fc.date({ noInvalidDate: true }),
+		fc.constant(null),
+		fc.constant(undefined)
+	),
+	node: fc.oneof(
+		{ maxDepth: 3 },
+		tie('leaf'),
+		fc.array(tie('node'), { maxLength: 4 }),
+		fc.dictionary(key, tie('node'), { maxKeys: 4, noNullPrototype: true })
+	),
+})).node
+
+const cloneableObject = fc.dictionary(key, cloneable, { maxKeys: 5, noNullPrototype: true })
+
+/** Recursively scribbles on every mutable node so a shared reference cannot hide. */
+function mutateEverything(value: unknown): void {
+	if (Array.isArray(value)) {
+		for (const item of [...value]) mutateEverything(item)
+		value.push('mutated')
+	} else if (value instanceof Date) {
+		value.setTime(0)
+	} else if (isPlainObject(value)) {
+		for (const item of Object.values(value)) mutateEverything(item)
+		value['mutated'] = true
+	}
+}
+
+describe('objects — properties', () => {
+	it('deepClone is structurally equal to the original', () => {
+		fc.assert(
+			fc.property(cloneable, (value) => {
+				expect(deepClone(value)).toEqual(value)
+			})
+		)
+	})
+
+	it('mutating the clone never touches the source', () => {
+		fc.assert(
+			// Two independently constructed but identical values: `reference` is the
+			// yardstick, so a deepClone that returned its input would be caught.
+			fc.property(fc.clone(cloneableObject, 2), ([source, reference]) => {
+				const clone = deepClone(source)
+				mutateEverything(clone)
+				expect(source).toEqual(reference)
+			})
+		)
+	})
+
+	it('deepMerge keeps every key from both sides', () => {
+		fc.assert(
+			fc.property(cloneableObject, cloneableObject, (target, source) => {
+				const merged = deepMerge(target, source)
+				for (const k of [...Object.keys(target), ...Object.keys(source)]) {
+					expect(Object.hasOwn(merged, k)).toBe(true)
+				}
+			})
+		)
+	})
+
+	it('deepMerge preserves nested structure — nested keys from both sides survive', () => {
+		fc.assert(
+			fc.property(cloneableObject, cloneableObject, (target, source) => {
+				const merged = deepMerge(target, source) as Record<string, unknown>
+				for (const k of Object.keys(source)) {
+					if (!isPlainObject(source[k]) || !isPlainObject(target[k])) continue
+					const nested = merged[k] as Record<string, unknown>
+					for (const nk of [...Object.keys(target[k]), ...Object.keys(source[k])]) {
+						expect(Object.hasOwn(nested, nk)).toBe(true)
+					}
+				}
+			})
+		)
+	})
+
+	// NOT commutative and NOT associative: the implementation is last-write-wins,
+	// so only the "source overrides target" direction is asserted.
+	it('deepMerge lets the source win for every non-plain-object value', () => {
+		fc.assert(
+			fc.property(cloneableObject, cloneableObject, (target, source) => {
+				const merged = deepMerge(target, source) as Record<string, unknown>
+				for (const [k, v] of Object.entries(source)) {
+					if (!isPlainObject(v)) expect(merged[k]).toBe(v)
+				}
+			})
+		)
+	})
+
+	it('deepMerge with an empty object is the identity on either side', () => {
+		fc.assert(
+			fc.property(cloneableObject, (obj) => {
+				expect(deepMerge(obj, {})).toEqual(obj)
+				expect(deepMerge({}, obj)).toEqual(obj)
+			})
+		)
+	})
+
+	it('deepMerge is idempotent in its source argument', () => {
+		fc.assert(
+			fc.property(cloneableObject, cloneableObject, (target, source) => {
+				const once = deepMerge(target, source)
+				expect(deepMerge(once, source)).toEqual(once)
+			})
+		)
+	})
+
+	it('deepMerge does not mutate either input', () => {
+		fc.assert(
+			fc.property(
+				fc.clone(cloneableObject, 2),
+				fc.clone(cloneableObject, 2),
+				([target, targetRef], [source, sourceRef]) => {
+					deepMerge(target, source)
+					expect(target).toEqual(targetRef)
+					expect(source).toEqual(sourceRef)
+				}
+			)
+		)
+	})
+})

--- a/src/promises/promises.prop.test.ts
+++ b/src/promises/promises.prop.test.ts
@@ -1,0 +1,70 @@
+import * as fc from 'fast-check'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withTimeout } from './index'
+
+// Everything here runs on fake timers: asserting real-clock bounds would be
+// flaky on a loaded CI box, and a flaky property test is worse than none.
+describe('promises — properties', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('withTimeout rejects with the supplied error once the window elapses', async () => {
+		await fc.assert(
+			fc.asyncProperty(fc.integer({ min: 1, max: 10_000 }), async (ms) => {
+				const error = new Error(`timed out after ${ms}ms`)
+				const raced = withTimeout(new Promise(() => {}), ms, error)
+				const assertion = expect(raced).rejects.toBe(error)
+				await vi.advanceTimersByTimeAsync(ms)
+				await assertion
+			}),
+			{ numRuns: 25 }
+		)
+	})
+
+	it('withTimeout never settles before the window, and always settles at it', async () => {
+		await fc.assert(
+			fc.asyncProperty(fc.integer({ min: 2, max: 10_000 }), async (ms) => {
+				let settled = false
+				const raced = withTimeout(new Promise(() => {}), ms, 'timeout')
+				raced.then(
+					() => {
+						settled = true
+					},
+					() => {
+						settled = true
+					}
+				)
+				await vi.advanceTimersByTimeAsync(ms - 1)
+				expect(settled).toBe(false)
+				await vi.advanceTimersByTimeAsync(1)
+				expect(settled).toBe(true)
+			}),
+			{ numRuns: 25 }
+		)
+	})
+
+	it('withTimeout resolves with the underlying value when it wins the race', async () => {
+		await fc.assert(
+			fc.asyncProperty(
+				fc.integer({ min: 1, max: 1_000 }),
+				fc.integer({ min: 1, max: 1_000 }),
+				fc.string(),
+				async (resolveAt, gap, value) => {
+					const slow = new Promise<string>((resolve) => {
+						setTimeout(() => resolve(value), resolveAt)
+					})
+					const raced = withTimeout(slow, resolveAt + gap)
+					const assertion = expect(raced).resolves.toBe(value)
+					await vi.advanceTimersByTimeAsync(resolveAt + gap)
+					await assertion
+				}
+			),
+			{ numRuns: 25 }
+		)
+	})
+})


### PR DESCRIPTION
Closes #78

Property tests for the modules whose invariants are cheap to state. Previously only `arrays`, `strings` and `numbers` had `*.prop.test.ts` files.

New: `src/objects/objects.prop.test.ts`, `src/promises/promises.prop.test.ts`, `src/json/json.prop.test.ts`. Extended: `src/numbers/numbers.prop.test.ts`.

## Why `numbers` was extended rather than a new `math` file

The issue asks for `math/clamp` and `math/roundTo`, but both live in `src/numbers/index.ts` (`:18` and `:28`) — `src/math/` does not export them. Adding a `math.prop.test.ts` would have tested the wrong module, so the clamp/roundTo properties went into the existing `numbers.prop.test.ts` alongside the ones already there.

Likewise `promises/retry` from the issue list **does not exist in `src/`**, so the promises file covers `withTimeout` instead.

## Two traps deliberately avoided

**`deepMerge` is neither commutative nor associative.** The issue suggests asserting those "where applicable" — the implementation is last-write-wins, so both would be false properties producing red tests that look like real bugs. What is asserted instead: every key from both sides survives, nested structure is preserved, source wins for every non-plain-object value, empty-object identity, idempotence in the source argument, and neither input is mutated. There is a comment at `objects.prop.test.ts:95` recording why the two obvious properties are absent.

**All timing properties run on fake timers.** Asserting real-clock bounds for `withTimeout` would be flaky on a loaded CI box, and a flaky property test is worse than none — it trains people to ignore red. `vi.useFakeTimers()` plus `advanceTimersByTimeAsync` makes the window assertions exact, including the strongest one: not settled at `ms - 1`, settled at `ms`.

`numRuns` is capped at 25 on the async properties to keep the suite quick.

## Verification

- `pnpm test --run` green, **3 consecutive runs**, no flakiness.
- Suite cost is negligible: 52 files / ~1.0s, against 49 files / ~1.0s before. Fake timers mean the timing properties add no real wall-clock delay.
- `pnpm typecheck` and `pnpm exec biome check src` clean.
- Confirmed the tests can fail — a property was temporarily inverted, went red, and was reverted.

No implementation file under `src/*/index.ts` was modified.