### PR TITLE
fix(types): return the wrapper type from debounce/throttle and type to()'s error slot as unknown

### DIFF
--- a/src/functions/functions.test-d.ts
+++ b/src/functions/functions.test-d.ts
@@ -15,7 +15,6 @@ describe('functions — types', () => {
 	it('debounce preserves the wrapped function parameters', () => {
 		const fn = (_a: string, _b: number) => {}
 		const debounced = debounce(fn, 100)
-		expectTypeOf(debounced).toEqualTypeOf<typeof fn>()
 		expectTypeOf(debounced).parameters.toEqualTypeOf<[string, number]>()
 		expectTypeOf(debounced).returns.toEqualTypeOf<void>()
 		// @ts-expect-error — arguments are still checked
@@ -25,19 +24,17 @@ describe('functions — types', () => {
 	it('throttle preserves the wrapped function parameters', () => {
 		const fn = (_event: { x: number }) => {}
 		const throttled = throttle(fn, 100)
-		expectTypeOf(throttled).toEqualTypeOf<typeof fn>()
 		expectTypeOf(throttled).parameters.toEqualTypeOf<[{ x: number }]>()
 		expectTypeOf(throttled).returns.toEqualTypeOf<void>()
 		// @ts-expect-error — arguments are still checked
 		throttled({ y: 1 })
 	})
 
-	it('debounce/throttle keep a non-void return type even though the wrapper drops it', () => {
-		// Current (unsound) behaviour: the `=> void` constraint accepts value-returning
-		// functions, so `T` — and therefore the returned type — still says `number`,
-		// while at runtime the wrapper returns undefined. Asserted as-is, not endorsed.
+	it('debounce/throttle return void even when the wrapped function returns a value', () => {
+		// The wrapper never forwards `fn`'s return value, so the type must not claim it does.
 		const fn = (n: number) => n * 2
-		expectTypeOf(debounce(fn, 10)).returns.toEqualTypeOf<number>()
-		expectTypeOf(throttle(fn, 10)).returns.toEqualTypeOf<number>()
+		expectTypeOf(debounce(fn, 10)).returns.toEqualTypeOf<void>()
+		expectTypeOf(throttle(fn, 10)).returns.toEqualTypeOf<void>()
+		expectTypeOf(debounce(fn, 10)).parameters.toEqualTypeOf<[number]>()
 	})
 })

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -18,27 +18,36 @@ export function once<T extends (...args: any[]) => any>(fn: T): T {
 
 /**
  * Returns a debounced version of a function.
+ * The wrapper defers the call, so it always returns `undefined` — never `fn`'s return value.
  * @param fn The function to debounce.
  * @param wait Milliseconds to wait.
  * @returns {Function}
  */
 
-export function debounce<T extends (...args: any[]) => void>(fn: T, wait: number): T {
+export function debounce<T extends (...args: any[]) => void>(
+	fn: T,
+	wait: number
+): (...args: Parameters<T>) => void {
 	let timeout: ReturnType<typeof setTimeout> | undefined
 	return function (this: any, ...args: any[]) {
 		clearTimeout(timeout)
 		timeout = setTimeout(() => fn.apply(this, args), wait)
-	} as T
+	}
 }
 
 /**
  * Returns a throttled version of a function.
+ * The wrapper drops calls inside the window, so it always returns `undefined` — never `fn`'s
+ * return value.
  * @param fn The function to throttle.
  * @param wait Milliseconds to wait between calls.
  * @returns {Function}
  */
 
-export function throttle<T extends (...args: any[]) => void>(fn: T, wait: number): T {
+export function throttle<T extends (...args: any[]) => void>(
+	fn: T,
+	wait: number
+): (...args: Parameters<T>) => void {
 	let last = 0
 	return function (this: any, ...args: any[]) {
 		const now = Date.now()
@@ -46,7 +55,7 @@ export function throttle<T extends (...args: any[]) => void>(fn: T, wait: number
 			last = now
 			fn.apply(this, args)
 		}
-	} as T
+	}
 }
 
 /**

--- a/src/promises/index.ts
+++ b/src/promises/index.ts
@@ -9,11 +9,12 @@ export function delay(ms: number): Promise<void> {
 
 /**
  * Wraps a promise and returns a tuple [error, result].
+ * The error slot is `unknown` — narrow it at the call site before touching its properties.
  * @param promise The promise to wrap.
- * @returns {Promise<[any, T | undefined]>}
+ * @returns {Promise<[unknown, T | undefined]>}
  */
 
-export async function to<T>(promise: Promise<T>): Promise<[any, T | undefined]> {
+export async function to<T>(promise: Promise<T>): Promise<[unknown, T | undefined]> {
 	try {
 		const result = await promise
 		return [null, result]

--- a/src/promises/promises.test-d.ts
+++ b/src/promises/promises.test-d.ts
@@ -10,8 +10,8 @@ describe('promises — types', () => {
 	})
 
 	it('to returns an [error, value] tuple with the value widened to undefined', () => {
-		// The error slot is `any` — see the note in the issue thread, not fixed here.
-		expectTypeOf(to(Promise.resolve('x'))).toEqualTypeOf<Promise<[any, string | undefined]>>()
+		// The error slot is `unknown`, so call sites have to narrow before using it.
+		expectTypeOf(to(Promise.resolve('x'))).toEqualTypeOf<Promise<[unknown, string | undefined]>>()
 	})
 
 	it('all/allSettled/race preserve the element type', () => {


### PR DESCRIPTION
`debounce` and `throttle` were declared to return `T`. TypeScript's
return-type-void rule lets a value-returning function satisfy the
`(...args: any[]) => void` constraint, so `T` inferred the full signature
including its return type and the `as T` cast hid the fact that the
wrapper returns `undefined`. `debounce((n: number) => n * 2, 10)(21) * 2`
typechecked and produced `NaN`. Both now return
`(...args: Parameters<T>) => void`, which is what the wrapper actually is,
and the casts are gone.

`to()` typed its error slot as `any`, which defeats the point of the
`[error, value]` tuple — `err.foo.bar` was accepted. It is now `unknown`,
forcing a narrow at the call site.

Neither change alters emitted JavaScript.

BREAKING CHANGE: `debounce` and `throttle` no longer claim to return the
wrapped function's return type. Code reading a debounced or throttled
call's return value now fails to compile — that code was already getting
`undefined` at runtime. `to()`'s error slot is `unknown` instead of `any`,
so call sites doing `err.message` directly must narrow first
(`err instanceof Error ? err.message : String(err)`).

Closes #144
