### PR TITLE
docs: open each module page with scope and rationale prose

### DIFF
--- a/apps/docs/docs/modules/abortController.md
+++ b/apps/docs/docs/modules/abortController.md
@@ -3,6 +3,8 @@ title: AbortController
 description: Utilities exported from @rtorcato/js-common/abortController.
 ---
 
+Cancellation plumbing for anything that speaks `AbortSignal` — create a controller, abort it on a timer, or turn a signal into a promise that rejects. It wraps the platform `AbortController` instead of inventing a cancellation type, so the same signal works with `fetch`, stream readers and any third-party API that accepts one. Aborting rejects your wrapper immediately, but the underlying work only really stops if it honours the signal.
+
 ```ts
 import { abortAfter, abortPromise, createAbortController } from '@rtorcato/js-common/abortController'
 ```

--- a/apps/docs/docs/modules/arrays.md
+++ b/apps/docs/docs/modules/arrays.md
@@ -3,6 +3,8 @@ title: Arrays
 description: Utilities exported from @rtorcato/js-common/arrays.
 ---
 
+Small, non-mutating helpers for everyday array work — chunking, grouping, deduping, taking the ends. Every function returns a new array and leaves its input untouched, including `shuffle`, which copies before running its Fisher-Yates pass. `unique` dedupes through a `Set`, so equality is SameValueZero — primitives compare by value, objects by reference, and two structurally identical objects both survive; use `groupBy` with a key function when you need value-based deduping.
+
 ```ts
 import { chunk, compact, first } from '@rtorcato/js-common/arrays'
 ```

--- a/apps/docs/docs/modules/boolean.md
+++ b/apps/docs/docs/modules/boolean.md
@@ -3,6 +3,8 @@ title: Boolean
 description: Utilities exported from @rtorcato/js-common/boolean.
 ---
 
+Named logical operators (`and`, `or`, `not`, `xor`) plus a boolean type guard and a coercion helper. The operators exist so boolean logic can be passed around as a value — into `reduce`, `map` or a `pipe` — not to replace `&&` and `||` in ordinary conditions. `toBoolean` understands the string forms `'true'`, `'false'`, `'1'` and `'0'` that `Boolean()` gets wrong for env vars and query params.
+
 ```ts
 import { and, isBoolean, not } from '@rtorcato/js-common/boolean'
 ```

--- a/apps/docs/docs/modules/colors.md
+++ b/apps/docs/docs/modules/colors.md
@@ -3,6 +3,8 @@ title: Colors
 description: Utilities exported from @rtorcato/js-common/colors.
 ---
 
+Hex-string colour maths — conversion to and from RGB, lightening and darkening by a percentage, a contrast-aware text colour, and random colours. Hex is the only input format because it is what CSS, design tokens and config files already carry; there is no colour-space interpolation and no perceptual (OKLCH/LAB) maths. `randomColor` draws from `Math.random`, so treat its output as decoration, never as an identifier.
+
 ```ts
 import { darken, hexToRgb, isValidHex } from '@rtorcato/js-common/colors'
 ```

--- a/apps/docs/docs/modules/console.md
+++ b/apps/docs/docs/modules/console.md
@@ -3,6 +3,8 @@ title: Console
 description: Utilities exported from @rtorcato/js-common/console.
 ---
 
+Two blunt instruments for the console: clear it, or silence it. `disableConsole` replaces `console.log` with a no-op and only does so when `NODE_ENV` is `production`, so a stray debug log cannot leak into a shipped build while your local output stays intact. When you need the output back afterwards use `logging`'s `captureConsole`, and for anything structured use `logger`.
+
 ```ts
 import { clearConsole, disableConsole } from '@rtorcato/js-common/console'
 ```

--- a/apps/docs/docs/modules/crypto.md
+++ b/apps/docs/docs/modules/crypto.md
@@ -3,6 +3,8 @@ title: Crypto
 description: Utilities exported from @rtorcato/js-common/crypto.
 ---
 
+Hashing, HMAC, base64 and random hex on top of `node:crypto` — which makes this module Node-only; it will not run in a browser or on an edge runtime. These are one-way digests and encodings, not encryption and not password storage: `hashString` with SHA-256 is the wrong tool for passwords (use argon2 or bcrypt). `randomHex` comes from `randomBytes`, unlike the `Math.random`-based helpers in `random`.
+
 ```ts
 import { base64Decode, base64Encode, hashString } from '@rtorcato/js-common/crypto'
 ```

--- a/apps/docs/docs/modules/currency.md
+++ b/apps/docs/docs/modules/currency.md
@@ -3,6 +3,8 @@ title: Currency
 description: Utilities exported from @rtorcato/js-common/currency.
 ---
 
+Money for display — formatting prices and compact notation, parsing them back, and looking up symbols, names and locales for ISO 4217 codes. Formatting delegates to `Intl.NumberFormat`, so symbol placement, digit counts and grouping come from the platform rather than a bundled table, and the currency-name list is loaded lazily to keep the module small. Amounts are plain `number`s: fine to render, wrong for accounting arithmetic, where integer minor units or a decimal library belong.
+
 ```ts
 import { convertCurrency, formatPrice, formatPriceCompact } from '@rtorcato/js-common/currency'
 ```

--- a/apps/docs/docs/modules/emails.md
+++ b/apps/docs/docs/modules/emails.md
@@ -3,6 +3,8 @@ title: Emails
 description: Utilities exported from @rtorcato/js-common/emails.
 ---
 
+Everyday address handling — validate, normalize, mask for display, extract the domain, flag free providers. Validation is a deliberately simple regex rather than RFC 5322: it catches typos and obvious junk, and the only real proof an address exists is delivering mail to it. `normalizeEmail` only trims and lowercases — it does not strip Gmail dots or `+` tags, because those rules are provider-specific and throw away information the user may have meant.
+
 ```ts
 import { getEmailDomain, isFreeEmailProvider, isValidEmail } from '@rtorcato/js-common/emails'
 ```

--- a/apps/docs/docs/modules/env.md
+++ b/apps/docs/docs/modules/env.md
@@ -3,6 +3,8 @@ title: Env
 description: Utilities exported from @rtorcato/js-common/env.
 ---
 
+Reading environment variables and validating them, with Zod schemas doing the validating. `getENV` throws when a variable is missing and no default was given — failing loudly at startup beats an `undefined` surfacing three layers deep in a request. `isDev`, `isProd` and `isTest` are plain `NODE_ENV` string comparisons, so they are cheap enough to call anywhere.
+
 ```ts
 import { RootApiEnvSchema, checkEnv, getENV } from '@rtorcato/js-common/env'
 ```

--- a/apps/docs/docs/modules/errors.md
+++ b/apps/docs/docs/modules/errors.md
@@ -3,6 +3,8 @@ title: Errors
 description: Utilities exported from @rtorcato/js-common/errors.
 ---
 
+Helpers for the error paths `try`/`catch` leaves awkward — asserting invariants, creating named errors, and pulling a message out of an `unknown` catch binding. TypeScript types a catch clause as `unknown`, so `getErrorMessage` exists to keep that narrowing out of every call site. When failure is an expected outcome rather than an exception, `try`'s `Result` tuples are usually the better shape.
+
 ```ts
 import { assert, createCustomError, getErrorMessage } from '@rtorcato/js-common/errors'
 ```

--- a/apps/docs/docs/modules/events.md
+++ b/apps/docs/docs/modules/events.md
@@ -3,6 +3,8 @@ title: Events
 description: Utilities exported from @rtorcato/js-common/events.
 ---
 
+Thin wrappers over the DOM `EventTarget` API — add a listener, dispatch a `CustomEvent`, await a single event as a promise. `on` returns its own removal function, so cleanup is a value you can store and call rather than a `removeEventListener` you must remember to mirror argument for argument. These are browser-side helpers; Node's `EventEmitter` is a different API and is not covered here.
+
 ```ts
 import { emit, on, once } from '@rtorcato/js-common/events'
 ```

--- a/apps/docs/docs/modules/fetch.md
+++ b/apps/docs/docs/modules/fetch.md
@@ -3,6 +3,8 @@ title: Fetch
 description: Utilities exported from @rtorcato/js-common/fetch.
 ---
 
+Small conveniences around the platform `fetch` — JSON GET and POST, plain text, a timeout wrapper and error handling. It stays a thin layer rather than an HTTP client: no retries, interceptors, base URLs or response caching, because those are application decisions (or a job for `ky`). `fetchWithTimeout` is built on `AbortController` with an 8 second default, so it composes with the `abortController` module.
+
 ```ts
 import { fetchText, fetchWithTimeout, getJson } from '@rtorcato/js-common/fetch'
 ```

--- a/apps/docs/docs/modules/file.md
+++ b/apps/docs/docs/modules/file.md
@@ -3,6 +3,8 @@ title: File
 description: Utilities exported from @rtorcato/js-common/file.
 ---
 
+Promise-based reads, writes, existence checks and deletes over `node:fs/promises`, plus a file-extension parser. Node-only, async-only and UTF-8 only — no sync variants and no encoding argument, since those are exactly the cases where you should reach for `node:fs` directly. `fileExists` answers a question about the past: the file can disappear before your next line runs, so where it matters, attempt the operation and handle the failure instead.
+
 ```ts
 import { deleteFile, fileExists, getFileExtension } from '@rtorcato/js-common/file'
 ```

--- a/apps/docs/docs/modules/formatting.md
+++ b/apps/docs/docs/modules/formatting.md
@@ -3,6 +3,8 @@ title: Formatting
 description: Utilities exported from @rtorcato/js-common/formatting.
 ---
 
+Display formatting with predictable, fixed-shape output — thousands separators, percentages, zero padding, and `YYYY-MM-DD` / `HH:MM:SS` timestamps. The date and time helpers take no format string and the number helpers default to `en-US`, which is the point: this module is for logs, filenames and CSVs, where output should not shift with the machine's locale. When the reader's locale does matter, use `i18n` or `currency`, which go through `Intl`.
+
 ```ts
 import { formatDate, formatDateTime, formatNumber } from '@rtorcato/js-common/formatting'
 ```

--- a/apps/docs/docs/modules/functions.md
+++ b/apps/docs/docs/modules/functions.md
@@ -3,6 +3,8 @@ title: Functions
 description: Utilities exported from @rtorcato/js-common/functions.
 ---
 
+Function decorators — `debounce`, `throttle`, `once` — plus `compose` and `pipe` for wiring functions together. The rate limiters wrap and return a new function rather than taking a config object, so they drop into an event handler in a single line. They are trailing-edge and timer-based with no `cancel` or `flush` handle; if you need to abandon work already in flight, pair them with `abortController`.
+
 ```ts
 import { compose, debounce, once } from '@rtorcato/js-common/functions'
 ```

--- a/apps/docs/docs/modules/geometry.md
+++ b/apps/docs/docs/modules/geometry.md
@@ -3,6 +3,8 @@ title: Geometry
 description: Utilities exported from @rtorcato/js-common/geometry.
 ---
 
+2D maths for points, rectangles and polygons — distance, angle, midpoint, area, and hit-testing. Coordinates are passed as plain numbers rather than `Point` or `Rect` objects, so nothing here needs a class, a canvas or an allocation per call, and it works equally for layout code, games and charts. Angles are radians to match `Math.atan2` and the Canvas API, and `distance2D` uses `Math.hypot`, which avoids overflow on large coordinates.
+
 ```ts
 import { angle2D, distance2D, midpoint2D } from '@rtorcato/js-common/geometry'
 ```

--- a/apps/docs/docs/modules/html.md
+++ b/apps/docs/docs/modules/html.md
@@ -3,6 +3,8 @@ title: Html
 description: Utilities exported from @rtorcato/js-common/html.
 ---
 
+Escaping, unescaping, stripping and detecting HTML in strings. `escapeHtml` is the one to reach for on any untrusted value you are about to interpolate into markup — it replaces the five significant characters and is safe by construction. `stripHtmlTags` and `containsHtml` are regex-based conveniences for input you already trust; when you must keep markup intact, use a real sanitizer such as DOMPurify instead.
+
 ```ts
 import { containsHtml, escapeHtml, stripHtmlTags } from '@rtorcato/js-common/html'
 ```

--- a/apps/docs/docs/modules/i18n.md
+++ b/apps/docs/docs/modules/i18n.md
@@ -3,6 +3,8 @@ title: I18n
 description: Utilities exported from @rtorcato/js-common/i18n.
 ---
 
+A minimal localisation layer — locale detection, `Intl`-backed number and date formatting, and a dictionary-lookup `t`. Formatting delegates to `Intl`, so the locale data is the platform's rather than the bundle's, while translation and `pluralize` are deliberately naive: a flat dictionary and basic English plurals. For ICU messages, per-language plural categories or namespaced catalogs, use `i18next` or FormatJS.
+
 ```ts
 import { detectLanguage, formatDateI18n, formatNumber } from '@rtorcato/js-common/i18n'
 ```

--- a/apps/docs/docs/modules/interval.md
+++ b/apps/docs/docs/modules/interval.md
@@ -3,6 +3,8 @@ title: Interval
 description: Utilities exported from @rtorcato/js-common/interval.
 ---
 
+Two functions: start a repeating timer, cancel it by id. They exist mainly to paper over the Node/browser split in what `setInterval` returns (`NodeJS.Timeout` versus `number`), so the same code type-checks in both. There is no drift correction and no awaiting of async callbacks — for a self-scheduling loop, `await sleep()` inside a `while` is clearer and gives you cancellation for free.
+
 ```ts
 import { clearIntervalById, runInterval } from '@rtorcato/js-common/interval'
 ```

--- a/apps/docs/docs/modules/json.md
+++ b/apps/docs/docs/modules/json.md
@@ -3,6 +3,8 @@ title: Json
 description: Utilities exported from @rtorcato/js-common/json.
 ---
 
+Parse, stringify, validate and deep-clone through JSON, with every operation returning a fallback instead of throwing. Parsing untrusted JSON is the classic case where a `try`/`catch` is pure noise, so `safeJsonParse` takes the fallback as an argument. `deepCloneJson` inherits JSON's limits — `undefined`, functions, `Date`s, `Map`s and cycles do not survive the round trip — so prefer `objects.deepClone` unless you specifically want the JSON-shaped result.
+
 ```ts
 import { deepCloneJson, isValidJson, safeJsonParse } from '@rtorcato/js-common/json'
 ```

--- a/apps/docs/docs/modules/logger.md
+++ b/apps/docs/docs/modules/logger.md
@@ -3,6 +3,8 @@ title: Logger
 description: Utilities exported from @rtorcato/js-common/logger.
 ---
 
+A single pre-configured Pino logger: pretty-printed and colourised in development, plain JSON at `info` level in production. It is an opinionated default so applications stop rewriting the same transport wiring, and JSON in production is what log aggregators want to ingest. `pino-pretty` is an optional dependency and the logger probes for it, falling back to JSON rather than throwing; if you need custom levels, redaction or child loggers, construct your own Pino instance — this export is intentionally not configurable.
+
 ```ts
 import { logger } from '@rtorcato/js-common/logger'
 ```

--- a/apps/docs/docs/modules/logging.md
+++ b/apps/docs/docs/modules/logging.md
@@ -3,6 +3,8 @@ title: Logging
 description: Utilities exported from @rtorcato/js-common/logging.
 ---
 
+Dependency-free logging — leveled `info` / `warn` / `error` helpers, a timestamped log, and `captureConsole` for recording console output. It writes through the global `console`, so it adds nothing to a bundle and runs anywhere; `logger` is the structured, Pino-backed alternative for services. `captureConsole` returns a restore function, which makes it useful in tests and for buffering output around a noisy operation.
+
 ```ts
 import { ConsoleLevel, captureConsole, error } from '@rtorcato/js-common/logging'
 ```

--- a/apps/docs/docs/modules/maps.md
+++ b/apps/docs/docs/modules/maps.md
@@ -3,6 +3,8 @@ title: Maps
 description: Utilities exported from @rtorcato/js-common/maps.
 ---
 
+Conversions and transforms for the native `Map` — to and from plain objects, merge, invert, map values. `Map` is the right structure for non-string keys, guaranteed insertion order and frequent adds and deletes, but it has none of the spread-and-merge ergonomics objects enjoy, which is the gap these fill. Every helper returns a new `Map`; later maps win on key collisions in `mergeMaps`, matching object spread.
+
 ```ts
 import { invertMap, mapToObject, mapValues } from '@rtorcato/js-common/maps'
 ```

--- a/apps/docs/docs/modules/math.md
+++ b/apps/docs/docs/modules/math.md
@@ -3,6 +3,8 @@ title: Math
 description: Utilities exported from @rtorcato/js-common/math.
 ---
 
+Four named arithmetic operations. They exist so arithmetic can be passed around as a value — into a `reduce`, a `pipe` or an operator lookup table — not as a replacement for `+` and `*`, which stay clearer in an ordinary expression. For aggregates over collections (`sum`, `average`, `clamp`, `roundTo`) use `numbers` instead.
+
 ```ts
 import { add, divide, multiply } from '@rtorcato/js-common/math'
 ```

--- a/apps/docs/docs/modules/mime-types.md
+++ b/apps/docs/docs/modules/mime-types.md
@@ -3,6 +3,8 @@ title: Mime Types
 description: Utilities exported from @rtorcato/js-common/mime-types.
 ---
 
+MIME-type lookup by file extension, plus the database behind it and its string-literal types. It is a vendored, TypeScript-ported subset of the `mime-types` package with `path.extname` removed, so it runs on edge runtimes where `node:path` is unavailable. `MimeType` and `FileExtension` are unions of every value in the database, which turns a typo into a compile error rather than a silent `false` at runtime.
+
 ```ts
 import { FileExtension, MimeType, MimeValue } from '@rtorcato/js-common/mime-types'
 ```

--- a/apps/docs/docs/modules/node.md
+++ b/apps/docs/docs/modules/node.md
@@ -3,6 +3,8 @@ title: Node
 description: Utilities exported from @rtorcato/js-common/node.
 ---
 
+Runtime questions about Node itself — is this Node, which major version, how long has the process been up — plus `requireOptional` for modules that may not be installed. The version helpers are for guarding features that need a floor and failing with a clear message instead of a cryptic crash deeper in. `requireOptional` returns `undefined` rather than throwing, which is the behaviour you want around optional peer dependencies.
+
 ```ts
 import { getNodeMajorVersion, getProcessUptime, isNode } from '@rtorcato/js-common/node'
 ```

--- a/apps/docs/docs/modules/numbers.md
+++ b/apps/docs/docs/modules/numbers.md
@@ -4,6 +4,8 @@ description: Numeric utilities — sum, average, clamp, random.
 sidebar_position: 3
 ---
 
+Aggregates and range maths over plain numbers — sum, average, rounding to a fixed precision, clamping, random integers. `roundTo` is the usual `Math.round(n * 10 ** d) / 10 ** d`, which is right for display but still bound by float representation, so keep money in integer minor units or a decimal library. `getRandomInt` is `Math.random`-based and inclusive at both ends — see `crypto` or `security` for anything an attacker should not be able to predict.
+
 ```ts
 import { sum, average, roundTo, clamp, getRandomInt } from '@rtorcato/js-common/numbers'
 

--- a/apps/docs/docs/modules/objects.md
+++ b/apps/docs/docs/modules/objects.md
@@ -3,6 +3,8 @@ title: Objects
 description: Utilities exported from @rtorcato/js-common/objects.
 ---
 
+Plain-object helpers — `pick`, `omit`, `deepMerge`, `deepClone` and a plain-object guard. `deepClone` is `structuredClone`, so `Date`s, `Map`s, `Set`s, typed arrays and cycles all survive while functions and class prototypes do not — that is the deliberate difference from `json.deepCloneJson`. `pick` and `omit` return shallow copies, and `deepMerge` recurses only into plain objects: arrays and class instances are replaced wholesale rather than merged.
+
 ```ts
 import { deepClone, deepMerge, isPlainObject } from '@rtorcato/js-common/objects'
 ```

--- a/apps/docs/docs/modules/os.md
+++ b/apps/docs/docs/modules/os.md
@@ -3,6 +3,8 @@ title: Os
 description: Utilities exported from @rtorcato/js-common/os.
 ---
 
+The handful of operating-system facts worth a named helper — platform, architecture, release, home and temp directories. Each one guards on `process` being present and returns `undefined` off Node rather than throwing, so a shared module can call them without a runtime check. They are passthroughs, so you get exactly what Node reports (`'darwin'`, not `'macOS'`); for browser-side platform sniffing use `system`.
+
 ```ts
 import { getHomeDir, getOsArch, getOsPlatform } from '@rtorcato/js-common/os'
 ```

--- a/apps/docs/docs/modules/process.md
+++ b/apps/docs/docs/modules/process.md
@@ -3,6 +3,8 @@ title: Process
 description: Utilities exported from @rtorcato/js-common/process.
 ---
 
+Process-scoped facts and actions — cwd, pid, platform, uptime, exit and CI detection. Every helper reads `process` at call time rather than at import, so tests can change the environment without module-cache tricks, and each returns `undefined` off Node instead of throwing. `isCI` checks the conventional variables (`CI`, `CONTINUOUS_INTEGRATION`, `BUILD_NUMBER`, `RUN_ID`) that providers set.
+
 ```ts
 import { exitProcess, getCwd, getProcessId } from '@rtorcato/js-common/process'
 ```

--- a/apps/docs/docs/modules/promises.md
+++ b/apps/docs/docs/modules/promises.md
@@ -3,6 +3,8 @@ title: Promises
 description: Utilities exported from @rtorcato/js-common/promises.
 ---
 
+Promise combinators and adapters — the standard `Promise` statics under stable names, plus `delay`, `withTimeout` and `to` for error-as-value handling. `to` returns an `[error, result]` tuple so a failure can be handled with an `if` instead of a `try`/`catch` block; `try`'s `Result` is the richer, type-narrowing version of the same idea. `withTimeout` is a `Promise.race`: it rejects on time but does not cancel, so the underlying work keeps running unless it honours an `AbortSignal`.
+
 ```ts
 import { all, allSettled, delay } from '@rtorcato/js-common/promises'
 ```

--- a/apps/docs/docs/modules/random.md
+++ b/apps/docs/docs/modules/random.md
@@ -3,6 +3,8 @@ title: Random
 description: Utilities exported from @rtorcato/js-common/random.
 ---
 
+Random integers, floats, booleans, strings and array picks. All of it is `Math.random` — fast, seedless and not cryptographically secure — which makes it right for test fixtures, sampling, jitter and visuals, and wrong for tokens, session ids or anything an attacker would like to predict (use `crypto.randomHex` or `security.generateSecureToken`). Note the asymmetry: `randomInt` includes both bounds, `randomFloat` excludes its maximum.
+
 ```ts
 import { randomBool, randomElement, randomFloat } from '@rtorcato/js-common/random'
 ```

--- a/apps/docs/docs/modules/regex.md
+++ b/apps/docs/docs/modules/regex.md
@@ -3,6 +3,8 @@ title: Regex
 description: Utilities exported from @rtorcato/js-common/regex.
 ---
 
+Regex conveniences — escape a string for literal use in a pattern, test, match all, split, replace all. `escapeRegExp` is the one that earns its place: interpolating user input into a `RegExp` without it gives you a broken pattern at best and catastrophic backtracking at worst. The rest are thin wrappers that add the `g` flag where it is needed and return plain arrays rather than iterators, so results are easy to destructure and inspect.
+
 ```ts
 import { escapeRegExp, matchAll, replaceAllRegex } from '@rtorcato/js-common/regex'
 ```

--- a/apps/docs/docs/modules/security.md
+++ b/apps/docs/docs/modules/security.md
@@ -3,6 +3,8 @@ title: Security
 description: Utilities exported from @rtorcato/js-common/security.
 ---
 
+A small set of security-adjacent helpers: password-strength checks, cryptographically secure tokens from `node:crypto`, and coarse string sanitisation. `generateSecureToken` uses `randomBytes` — the `Math.random` helpers in `random` are never an acceptable substitute here. `sanitizeString` strips only `<script>` blocks and inline `on*` handlers with regexes, so treat it as defence in depth: escape untrusted values with `html.escapeHtml`, or run a real sanitizer such as DOMPurify when markup must survive.
+
 ```ts
 import { generateSecureToken, isStrongPassword, sanitizeString } from '@rtorcato/js-common/security'
 ```

--- a/apps/docs/docs/modules/sets.md
+++ b/apps/docs/docs/modules/sets.md
@@ -3,6 +3,8 @@ title: Sets
 description: Utilities exported from @rtorcato/js-common/sets.
 ---
 
+Set algebra over the native `Set` — union, intersection, difference, subset and superset — plus array conversions. Membership is SameValueZero, so primitives compare by value and objects by reference; map objects to a key first if you need structural comparison. Every operation returns a new `Set` and leaves its inputs alone, and these exist for runtimes that do not yet ship the equivalent `Set` methods natively.
+
 ```ts
 import { arrayToSet, difference, intersection } from '@rtorcato/js-common/sets'
 ```

--- a/apps/docs/docs/modules/sleep.md
+++ b/apps/docs/docs/modules/sleep.md
@@ -3,6 +3,8 @@ title: Sleep
 description: Utilities exported from @rtorcato/js-common/sleep.
 ---
 
+Await a fixed delay, a random one, or an abortable one — plus `sleepSync`, which blocks. `sleepRandom` is for jitter (retry backoff, staggering pollers), and `sleepWithAbort` is the one to use in anything cancellable, since a plain `sleep` holds its timer to the end. `sleepSync` busy-waits in a loop and freezes the event loop entirely — acceptable in a throwaway script, never in a server request path.
+
 ```ts
 import { sleep, sleepRandom, sleepSync } from '@rtorcato/js-common/sleep'
 ```

--- a/apps/docs/docs/modules/strings.md
+++ b/apps/docs/docs/modules/strings.md
@@ -4,6 +4,8 @@ description: String utilities — slugify, truncate, casing.
 sidebar_position: 4
 ---
 
+Everyday string shaping — slugs, truncation, casing, emoji stripping. Every function returns a new string and leaves its input alone; `truncate` counts its ellipsis inside the requested length rather than adding to it. `slugify` strips diacritics and then keeps only `a-z0-9` and hyphens, which makes it URL-safe by construction but also means non-Latin scripts slug to an empty string — transliterate first if you need to support them.
+
 ```ts
 import { slugify, truncate, capitalize, removeEmojis } from '@rtorcato/js-common/strings'
 

--- a/apps/docs/docs/modules/system.md
+++ b/apps/docs/docs/modules/system.md
@@ -3,6 +3,8 @@ title: System
 description: Utilities exported from @rtorcato/js-common/system.
 ---
 
+Platform detection for client-side code — operating system, mobile platform, touch support. It reads `navigator.userAgent`, which is a heuristic and not a fact: browsers misreport, and iPadOS presents itself as macOS. Prefer feature detection where one exists, keep these for the cases where behaviour genuinely differs by platform (shortcut labels, store links), and use `os` or `process` on the server.
+
 ```ts
 import { getPlatform, isAndroid, isIOS } from '@rtorcato/js-common/system'
 ```

--- a/apps/docs/docs/modules/try.md
+++ b/apps/docs/docs/modules/try.md
@@ -3,6 +3,8 @@ title: Try
 description: Utilities exported from @rtorcato/js-common/try.
 ---
 
+Go-style `Result` values for async code: `tryCatch` runs a function and hands back a success or failure branch instead of throwing. The point is the type system — a `Result` cannot be read without acknowledging the error branch, whereas a `try`/`catch` binding is `unknown` and easy to ignore. Use it where failure is an expected outcome, and keep throwing for genuinely exceptional states that no caller can sensibly handle.
+
 ```ts
 import { Failure, Result, Success } from '@rtorcato/js-common/try'
 ```

--- a/apps/docs/docs/modules/url.md
+++ b/apps/docs/docs/modules/url.md
@@ -3,6 +3,8 @@ title: Url
 description: Utilities exported from @rtorcato/js-common/url.
 ---
 
+URL parsing and query-string editing built on the platform `URL` — hostname, params, joining segments, setting and removing query parameters. Delegating to `URL` means percent-encoding, internationalised domains and relative resolution are the platform's problem rather than a regex's; `isValidUrl` is literally an attempted `new URL()`. `joinUrl` is the exception — plain string joining with slash normalisation, for assembling a path before you have a base.
+
 ```ts
 import { getHostname, getQueryParams, isValidUrl } from '@rtorcato/js-common/url'
 ```

--- a/apps/docs/docs/modules/uuid.md
+++ b/apps/docs/docs/modules/uuid.md
@@ -4,6 +4,8 @@ description: Generate and validate UUIDs.
 sidebar_position: 5
 ---
 
+UUID generation, validation and conversion, wrapping the `uuid` and `short-uuid` packages rather than hand-rolling either. Generation draws from a CSPRNG and validation is version-aware, so a plausible-looking but malformed id is rejected instead of slipping through a loose regex. v4 is the default when you want no embedded information; v7 is there when you want time-ordered ids that index well as database primary keys, and the short forms are the same value in a shorter alphabet, not a different id.
+
 ```ts
 import { generateUUID, isValidUUID } from '@rtorcato/js-common/uuid'
 

--- a/apps/docs/docs/modules/validation.md
+++ b/apps/docs/docs/modules/validation.md
@@ -3,6 +3,8 @@ title: Validation
 description: Utilities exported from @rtorcato/js-common/validation.
 ---
 
+Runtime type guards for values arriving from outside the program — JSON bodies, query params, config files. Each one returns a TypeScript type predicate, so a check narrows the type at the call site instead of merely returning `true`; `isNumber` also rejects `NaN`, which `typeof` will happily call a number. This is a guard set, not a schema validator — for object shapes, coercion and useful error messages, reach for Zod, as the `env` module does.
+
 ```ts
 import { isArray, isBoolean, isDefined } from '@rtorcato/js-common/validation'
 ```


### PR DESCRIPTION
Every module index page now leads with 2-3 sentences on when to reach for
the module and the design choices behind it, with the export table below.

Closes #83
