### PR TITLE
docs: add task-oriented recipes section

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ Index of open work for `@rtorcato/js-common`. Each row links to a GitHub issue �
 - [ ] [#82](https://github.com/rtorcato/js-common/issues/82) — Runnable examples on every function (input → output snippets; stretch: live playground)
 - [ ] [#83](https://github.com/rtorcato/js-common/issues/83) — Module overview prose, not just tables (when to reach for it + design rationale)
 - [x] [#84](https://github.com/rtorcato/js-common/issues/84) — "See also" cross-links between related modules
-- [ ] [#85](https://github.com/rtorcato/js-common/issues/85) — Recipes / cookbook section (task-oriented pages composing multiple modules)
+- [x] [#85](https://github.com/rtorcato/js-common/issues/85) — Recipes / cookbook section (task-oriented pages composing multiple modules)
 - [ ] [#86](https://github.com/rtorcato/js-common/issues/86) — OG/social card images, custom 404, `og:image` metadata
 - [x] [#87](https://github.com/rtorcato/js-common/issues/87) — Surface migration page from homepage hero
 - [ ] [#74](https://github.com/rtorcato/js-common/issues/74) — README references undefined export `validateEmail`

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -98,6 +98,7 @@ See the [full module overview](./modules/overview.md) for the complete list.
 
 ## Next steps
 
+- [**Recipes**](./recipes/index.md) — task-oriented walkthroughs that combine several modules.
 - [**Tree-shaking & imports**](./guides/tree-shaking.md) — how the subpath exports work and how to verify.
 - [**CLI**](./guides/cli.md) — run utilities from your terminal.
 - [**Module overview**](./modules/overview.md) — every subpath with examples.

--- a/apps/docs/docs/recipes/debounce-a-search-input.md
+++ b/apps/docs/docs/recipes/debounce-a-search-input.md
@@ -1,0 +1,120 @@
+---
+title: Debounce a search input
+description: One request per pause in typing, stale responses discarded — debounce plus an AbortController.
+---
+
+A search box that fires a request per keystroke sends eight requests for
+"debounce" and renders whichever one happens to land last. Two problems, two
+fixes: [`debounce`](../modules/functions.md) collapses the keystrokes,
+and an [`AbortController`](../modules/abortController.md) cancels the request
+that a newer keystroke has made irrelevant.
+
+## The code
+
+```ts
+import { createAbortController } from '@rtorcato/js-common/abortController'
+import { debounce } from '@rtorcato/js-common/functions'
+import { getErrorMessage } from '@rtorcato/js-common/errors'
+import { tryCatch } from '@rtorcato/js-common/try'
+
+export type SearchHit = { id: string; title: string }
+
+export type SearchHandlers = {
+  onResults: (hits: SearchHit[]) => void
+  onError?: (message: string) => void
+}
+
+/**
+ * Returns a function to call on every keystroke. It fires at most one request
+ * per `wait` ms of quiet, and aborts any request still in flight.
+ */
+export function createSearch({ onResults, onError }: SearchHandlers, wait = 300) {
+  let inFlight: AbortController | null = null
+
+  async function run(query: string) {
+    inFlight?.abort() // a newer query supersedes the old one
+    const { controller, signal } = createAbortController()
+    inFlight = controller
+
+    const { data, error } = await tryCatch<SearchHit[]>(async () => {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`, { signal })
+      if (!res.ok) throw new Error(`Search failed with ${res.status}`)
+      return res.json()
+    })
+
+    // Aborted requests reject; that is expected, not an error worth surfacing.
+    if (signal.aborted) return
+
+    if (error) onError?.(getErrorMessage(error))
+    else onResults(data)
+  }
+
+  return debounce((query: string) => {
+    void run(query)
+  }, wait)
+}
+```
+
+Wire it to an input — the debounced function is created once, not per render:
+
+```ts
+const search = createSearch({
+  onResults: (hits) => renderResults(hits),
+  onError: (message) => renderError(message),
+})
+
+input.addEventListener('input', (event) => {
+  search((event.target as HTMLInputElement).value)
+})
+```
+
+In React, keep it in a `useMemo`/`useRef` so a re-render does not create a
+fresh timer:
+
+```tsx
+const search = useMemo(() => createSearch({ onResults: setHits }), [])
+```
+
+## Why both
+
+`debounce` alone still races. Type `ab`, pause 300 ms, type `c`: two requests
+go out, and if the first is slower you render results for `ab` over results for
+`abc`. The `signal.aborted` check is what makes the last keystroke win.
+
+## Empty queries
+
+Debouncing does not stop a request for `""` after the user clears the box. Guard
+before calling:
+
+```ts
+input.addEventListener('input', (event) => {
+  const query = (event.target as HTMLInputElement).value.trim()
+  if (!query) {
+    renderResults([])
+    return
+  }
+  search(query)
+})
+```
+
+## Throttle instead?
+
+`debounce` waits for a pause — right for search, where only the final query
+matters. [`throttle`](../modules/functions.md) fires at a steady maximum rate —
+right for scroll, resize, and drag handlers, where you want continuous
+(but bounded) updates rather than one at the end.
+
+:::note No `.cancel()`
+`debounce` returns a plain function with no `cancel` or `flush` method. To stop a
+pending call, abort the work it would do — as above — or hold a flag the
+callback checks after it fires. If you unmount mid-flight, call
+`controller.abort()` in your cleanup.
+:::
+
+## See also
+
+- [functions](../modules/functions.md) — debounce, throttle, once, compose
+- [abortController](../modules/abortController.md) — cancel in-flight work with an `AbortSignal`
+- [try](../modules/try.md) — `Result` values instead of thrown exceptions
+- [fetch](../modules/fetch.md) — JSON helpers and fetch with a timeout
+- [Retry an async operation with exponential backoff](./retry-with-exponential-backoff.md)

--- a/apps/docs/docs/recipes/format-date-for-locale.md
+++ b/apps/docs/docs/recipes/format-date-for-locale.md
@@ -1,0 +1,111 @@
+---
+title: Format a date for a user's locale
+description: Turn an ISO timestamp from an API into a string a reader recognises — relative for recent dates, locale-aware otherwise.
+---
+
+An API hands you `"2026-06-12T14:30:00Z"`. A reader wants either "yesterday" or
+"12 June 2026 at 15:30" — never the raw ISO string, and never a US format for a
+German visitor.
+
+Three modules cover it: [`datetime`](../modules/datetime.md) parses the string,
+[`date`](../modules/date.md) decides whether it is recent enough for a relative
+label, and [`i18n`](../modules/i18n.md) formats the rest through `Intl`.
+
+## The code
+
+```ts
+import { daysBetween, formatRelative } from '@rtorcato/js-common/date'
+import { parseIsoDateTime } from '@rtorcato/js-common/datetime'
+import { formatDateI18n } from '@rtorcato/js-common/i18n'
+
+/**
+ * Formats an ISO timestamp for display.
+ * Returns `null` for input that is not a valid date, so the caller decides
+ * what to render instead of getting "Invalid Date" in the UI.
+ */
+export function formatTimestamp(iso: string, locale?: string, now = new Date()): string | null {
+  const date = parseIsoDateTime(iso)
+  if (!date) return null
+
+  // Yesterday / today / tomorrow read better than a full date.
+  if (Math.abs(daysBetween(date, now)) <= 1) return formatRelative(date, now)
+
+  return formatDateI18n(date, locale, { dateStyle: 'long', timeStyle: 'short' })
+}
+```
+
+```ts
+formatTimestamp('2026-06-11T14:30:00Z', 'en-GB', new Date('2026-06-12T09:00:00Z'))
+// "yesterday"
+
+formatTimestamp('2026-06-12T14:30:00Z', 'en-GB', new Date('2026-08-01T09:00:00Z'))
+// "12 June 2026 at 15:30"
+
+formatTimestamp('2026-06-12T14:30:00Z', 'de-DE', new Date('2026-08-01T09:00:00Z'))
+// "12. Juni 2026 um 16:30"
+
+formatTimestamp('not a date')
+// null
+```
+
+## Picking the locale
+
+Passing `locale` explicitly is the reliable option — take it from the user's
+account settings, an `Accept-Language` header, or the route.
+
+If you have nothing, `detectLanguage()` gives you a fallback:
+
+```ts
+import { detectLanguage } from '@rtorcato/js-common/i18n'
+
+const locale = user.locale ?? detectLanguage() // "en" if nothing is detectable
+formatTimestamp(iso, locale)
+```
+
+:::caution `detectLanguage` drops the region
+It returns the language only — a `navigator.language` of `"en-GB"` becomes
+`"en"`, so dates format as US English. In the browser, prefer
+`navigator.language` directly when the region matters; use `detectLanguage()`
+for its `defaultLang` fallback on the server.
+:::
+
+Leaving `locale` as `undefined` is also valid: `Intl` then uses the runtime's
+default locale. That is the right call in a browser and the wrong one on a
+server, where the runtime locale is the machine's, not the reader's.
+
+## Timezones
+
+`Intl.DateTimeFormat` formats in the runtime's timezone unless you say
+otherwise. On a server that is usually UTC, which is rarely what the reader
+wants. Pass the zone through when you know it:
+
+```ts
+formatDateI18n(date, 'en-GB', {
+  dateStyle: 'long',
+  timeStyle: 'short',
+  timeZone: user.timeZone, // e.g. "Europe/Berlin"
+})
+```
+
+For anything beyond formatting — timezone arithmetic, durations, parsing
+non-ISO formats — reach for [luxon](https://moment.github.io/luxon/) or
+[date-fns](https://date-fns.org/). The `date`/`datetime` modules are
+deliberately thin.
+
+## Numbers travel with dates
+
+The same `Intl` treatment applies to any number rendered next to that date:
+
+```ts
+import { formatNumber } from '@rtorcato/js-common/i18n'
+
+formatNumber(1234.56, 'de-DE') // "1.234,56"
+formatNumber(0.42, 'en-US', { style: 'percent' }) // "42%"
+```
+
+## See also
+
+- [datetime](../modules/datetime.md) — ISO parsing, ISO weeks and Unix timestamps
+- [date](../modules/date.md) — calendar-day helpers — add, diff, compare, format
+- [i18n](../modules/i18n.md) — `Intl` wrappers for dates, numbers and language detection
+- [currency](../modules/currency.md) — price formatting and currency codes

--- a/apps/docs/docs/recipes/generate-a-unique-slug.md
+++ b/apps/docs/docs/recipes/generate-a-unique-slug.md
@@ -1,0 +1,103 @@
+---
+title: Generate a slug and keep it unique
+description: Turn a title into a URL-safe slug, then make sure it does not collide with one you already published.
+---
+
+`slugify` turns "Café & Résumé" into `cafe-resume`. What it cannot know is that
+you already have a `cafe-resume`. This recipe pairs
+[`slugify`](../modules/strings.md) with [`unique`](../modules/arrays.md) to
+produce a slug that is safe for a URL *and* free.
+
+## The code
+
+```ts
+import { unique } from '@rtorcato/js-common/arrays'
+import { slugify } from '@rtorcato/js-common/strings'
+
+const MAX_SLUG_LENGTH = 60
+
+/**
+ * Slugifies a title and appends `-2`, `-3`, … until the result is not taken.
+ * `taken` may contain duplicates — they are collapsed before the lookup.
+ */
+export function uniqueSlug(title: string, taken: string[] = []): string {
+  const base = trimSlug(slugify(title)) || 'untitled'
+  const used = new Set(unique(taken))
+
+  if (!used.has(base)) return base
+
+  let suffix = 2
+  while (used.has(`${base}-${suffix}`)) suffix++
+  return `${base}-${suffix}`
+}
+
+/** Cuts a slug to length without leaving a trailing or half-eaten hyphen. */
+function trimSlug(slug: string): string {
+  if (slug.length <= MAX_SLUG_LENGTH) return slug
+  return slug.slice(0, MAX_SLUG_LENGTH).replace(/-[^-]*$/, '')
+}
+```
+
+```ts
+uniqueSlug('Café & Résumé') // "cafe-resume"
+uniqueSlug('Hello World!', ['hello-world']) // "hello-world-2"
+uniqueSlug('Hello World!', ['hello-world', 'hello-world-2']) // "hello-world-3"
+uniqueSlug('🎉🎉🎉') // "untitled" — nothing slug-safe survives
+```
+
+The `|| 'untitled'` matters: `slugify` strips everything that is not
+`[a-z0-9-]`, so a title made entirely of emoji, CJK characters, or punctuation
+comes back as an empty string.
+
+## Slugging a whole batch
+
+Importing a list of posts hits a second kind of collision — two titles in the
+same batch. Feed each result back into the taken list:
+
+```ts
+export function slugifyAll(titles: string[], taken: string[] = []): string[] {
+  const seen = [...taken]
+  return titles.map((title) => {
+    const slug = uniqueSlug(title, seen)
+    seen.push(slug)
+    return slug
+  })
+}
+
+slugifyAll(['Hello World', 'Hello, world!', 'Hello World'])
+// ["hello-world", "hello-world-2", "hello-world-3"]
+```
+
+## Where `taken` comes from
+
+Reading every existing slug into memory works up to a few thousand rows. Beyond
+that, query the ones that could collide:
+
+```sql
+SELECT slug FROM posts WHERE slug = $1 OR slug LIKE $1 || '-%';
+```
+
+:::caution Uniqueness is the database's job
+Two requests can generate `hello-world-2` at the same time and both pass the
+check. Keep a `UNIQUE` constraint on the column, and retry with the next suffix
+when the insert fails. The helper avoids collisions; the constraint prevents
+them.
+:::
+
+If suffixes are not worth the round trip, append a short random token instead —
+collisions become improbable rather than impossible, and no lookup is needed:
+
+```ts
+import { randomString } from '@rtorcato/js-common/random'
+
+// Pass a lowercase alphabet — the default charset includes A–Z.
+const token = randomString(6, 'abcdefghijklmnopqrstuvwxyz0123456789')
+const slug = `${slugify(title)}-${token}` // "hello-world-a7f3k2"
+```
+
+## See also
+
+- [strings](../modules/strings.md) — slugify, truncate, casing, emoji stripping
+- [arrays](../modules/arrays.md) — chunk, unique, groupBy and other array helpers
+- [random](../modules/random.md) — random ints, floats, strings and array picks
+- [url](../modules/url.md) — parse, validate and edit URLs and query params

--- a/apps/docs/docs/recipes/index.md
+++ b/apps/docs/docs/recipes/index.md
@@ -1,0 +1,22 @@
+---
+title: Recipes
+description: Task-oriented walkthroughs that combine several js-common modules to solve a concrete problem.
+---
+
+The [module pages](../modules/overview.md) tell you what each function does.
+These pages start from a problem instead — the kind you arrive at from a search
+engine — and show the whole solution, including the parts that are not
+`js-common` at all.
+
+Every snippet is copy-pasteable as written.
+
+| Recipe | Modules |
+| --- | --- |
+| [Format a date for a user's locale](./format-date-for-locale.md) | `date`, `datetime`, `i18n` |
+| [Debounce a search input](./debounce-a-search-input.md) | `functions`, `abortController`, `try`, `errors` |
+| [Safely parse untrusted JSON](./parse-untrusted-json.md) | `json`, `validation` |
+| [Generate a slug and keep it unique](./generate-a-unique-slug.md) | `strings`, `arrays`, `random` |
+| [Retry an async operation with exponential backoff](./retry-with-exponential-backoff.md) | `promises`, `numbers`, `random`, `try` |
+
+Missing one you needed? [Open an issue](https://github.com/rtorcato/js-common/issues) —
+the gaps people hit are the best guide to what to write next.

--- a/apps/docs/docs/recipes/parse-untrusted-json.md
+++ b/apps/docs/docs/recipes/parse-untrusted-json.md
@@ -1,0 +1,119 @@
+---
+title: Safely parse untrusted JSON
+description: Parse JSON from a request body, a webhook, or localStorage without throwing — and without trusting the shape that comes back.
+---
+
+`JSON.parse` fails two ways on untrusted input: it throws on malformed text, and
+it happily returns `{"id": "not-a-number"}` typed as whatever you asserted.
+[`safeJsonParse`](../modules/json.md) handles the first;
+[`validation`](../modules/validation.md) type guards handle the second.
+
+## The code
+
+```ts
+import { safeJsonParse } from '@rtorcato/js-common/json'
+import { isNumber, isObject, isString } from '@rtorcato/js-common/validation'
+
+export type User = { id: number; email: string }
+
+function isUser(value: unknown): value is User {
+  if (!isObject(value)) return false
+  const candidate = value as Record<string, unknown>
+  return isNumber(candidate.id) && isString(candidate.email)
+}
+
+/**
+ * Parses a JSON string into a `User`, or returns `null` if the text is not
+ * valid JSON or does not have the expected shape.
+ */
+export function parseUser(raw: string): User | null {
+  const parsed = safeJsonParse<unknown>(raw)
+  return isUser(parsed) ? parsed : null
+}
+```
+
+```ts
+parseUser('{"id":1,"email":"a@b.com"}') // { id: 1, email: "a@b.com" }
+parseUser('{"id":"1","email":"a@b.com"}') // null — id is a string
+parseUser('{ not json') // null
+parseUser('null') // null
+```
+
+`safeJsonParse` never throws: it returns the fallback (`null` by default) when
+parsing fails. Pass your own fallback when a default value beats a null check:
+
+```ts
+const settings = safeJsonParse(localStorage.getItem('settings') ?? '', {
+  theme: 'system',
+})
+```
+
+## Telling "invalid" from "the value was null"
+
+`safeJsonParse('null')` returns `null` — the parse succeeded and the value *is*
+null. If that distinction matters, check validity first:
+
+```ts
+import { isValidJson, safeJsonParse } from '@rtorcato/js-common/json'
+
+if (!isValidJson(raw)) {
+  throw new Error('Malformed JSON body')
+}
+const value = safeJsonParse<unknown>(raw)
+```
+
+`isValidJson` parses the string a second time, so use it where correctness
+matters more than the extra pass, not in a hot loop.
+
+## Reject oversized payloads first
+
+A 50 MB body will block the event loop inside `JSON.parse` before any of your
+validation runs. Cap the size at the edge:
+
+```ts
+const MAX_BODY_BYTES = 1024 * 100 // 100 KB
+
+export function parseBody(raw: string): User | null {
+  if (raw.length > MAX_BODY_BYTES) return null
+  return parseUser(raw)
+}
+```
+
+## Watch what you do with the parsed object
+
+`JSON.parse` itself is safe — a `"__proto__"` key becomes an own property, not a
+prototype change. The risk arrives when you *merge* that object into something
+trusted. Copy the fields you expect rather than spreading an untrusted object
+into config or defaults:
+
+```ts
+// ✅ only the fields you asked for
+const user: User = { id: parsed.id, email: parsed.email }
+
+// ❌ carries along whatever the sender added
+const user = { ...defaults, ...parsed }
+```
+
+## When the shape grows
+
+Hand-written guards stay readable for two or three fields. Past that, use a
+schema library — [zod](https://zod.dev/) is already a dependency of this
+package, so it costs you nothing extra:
+
+```ts
+import { z } from 'zod'
+
+const UserSchema = z.object({ id: z.number(), email: z.email() })
+
+export function parseUser(raw: string): User | null {
+  const result = UserSchema.safeParse(safeJsonParse<unknown>(raw))
+  return result.success ? result.data : null
+}
+```
+
+## See also
+
+- [json](../modules/json.md) — safe parse/stringify and JSON deep clone
+- [validation](../modules/validation.md) — type guards — `isString`, `isNumber`, `isObject`
+- [try](../modules/try.md) — `Result` values instead of thrown exceptions
+- [security](../modules/security.md) — string sanitizing, secure tokens, password strength

--- a/apps/docs/docs/recipes/retry-with-exponential-backoff.md
+++ b/apps/docs/docs/recipes/retry-with-exponential-backoff.md
@@ -1,0 +1,138 @@
+---
+title: Retry an async operation with exponential backoff
+description: A retry helper built from delay, clamp and tryCatch — with jitter, a cap, and a rule for which errors are worth retrying.
+---
+
+A flaky upstream deserves a second attempt; a `404` does not. This recipe builds
+a retry helper from [`delay`](../modules/promises.md),
+[`clamp`](../modules/numbers.md), [`randomInt`](../modules/random.md) and
+[`tryCatch`](../modules/try.md) — about twenty lines, no dependency.
+
+## The code
+
+```ts
+import { clamp } from '@rtorcato/js-common/numbers'
+import { delay } from '@rtorcato/js-common/promises'
+import { randomInt } from '@rtorcato/js-common/random'
+import { type Result, tryCatch } from '@rtorcato/js-common/try'
+
+export type RetryOptions = {
+  /** Total attempts, including the first. Default 4. */
+  attempts?: number
+  /** Delay before the first retry, in ms. Doubles each round. Default 200. */
+  baseMs?: number
+  /** Upper bound on a single delay, in ms. Default 10_000. */
+  maxMs?: number
+  /** Return false to stop early — e.g. on a 4xx. Default: retry everything. */
+  shouldRetry?: (error: unknown) => boolean
+}
+
+/**
+ * Runs `fn`, retrying failures with exponential backoff and jitter.
+ * Resolves to a `Result` — the last error if every attempt failed.
+ */
+export async function retry<T>(
+  fn: () => Promise<T>,
+  { attempts = 4, baseMs = 200, maxMs = 10_000, shouldRetry = () => true }: RetryOptions = {}
+): Promise<Result<T>> {
+  let last: Result<T> = { data: null, error: new Error('retry: attempts must be at least 1') }
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    last = await tryCatch(fn)
+    if (!last.error) return last
+    if (attempt === attempts - 1 || !shouldRetry(last.error)) break
+
+    const backoff = clamp(baseMs * 2 ** attempt, baseMs, maxMs)
+    await delay(randomInt(Math.round(backoff / 2), backoff)) // jitter
+  }
+
+  return last
+}
+```
+
+Call it and branch on the `Result` — no try/catch at the call site:
+
+```ts
+import { isSuccess } from '@rtorcato/js-common/try'
+
+const result = await retry(() => getJson<Report>('/api/report'))
+
+if (isSuccess(result)) {
+  render(result.data)
+} else {
+  logger.error({ err: result.error }, 'report fetch failed after 4 attempts')
+}
+```
+
+## Why jitter
+
+Without it, every client that failed at the same moment retries at the same
+moment — the thundering herd that keeps a recovering service down. Sleeping a
+random amount between half the backoff and the full backoff spreads the retries
+out. With the defaults, the waits are roughly 100–200 ms, 200–400 ms, then
+400–800 ms.
+
+`clamp` is what stops the doubling from running away: attempt 10 would otherwise
+wait about 200 seconds.
+
+## Retry the right errors
+
+Retrying a `400` just fails four times more slowly. Pass `shouldRetry` to
+retry only what a retry can fix — network failures, `429`, and `5xx`:
+
+```ts
+class HttpError extends Error {
+  constructor(readonly status: number) {
+    super(`HTTP ${status}`)
+  }
+}
+
+const result = await retry(() => fetchReport(), {
+  shouldRetry: (error) =>
+    !(error instanceof HttpError) || error.status === 429 || error.status >= 500,
+})
+```
+
+:::caution Only retry idempotent work
+A `GET` or a `PUT` is safe to repeat. A `POST` that charges a card is not — a
+timeout does not tell you whether the server processed the request. Retry those
+only behind an idempotency key.
+:::
+
+## Bound each attempt
+
+Backoff does not help if a single attempt hangs forever.
+[`withTimeout`](../modules/promises.md) caps one attempt; the retry loop caps
+the whole operation:
+
+```ts
+import { withTimeout } from '@rtorcato/js-common/promises'
+
+const result = await retry(() => withTimeout(fetchReport(), 5_000), { attempts: 3 })
+```
+
+Worst case here is 3 × 5 s of work plus the backoff waits — a number you can
+put in a timeout budget.
+
+## Let the caller cancel
+
+Pass an `AbortSignal` through to the work and check it between attempts, so a
+cancelled request stops retrying instead of finishing its schedule:
+
+```ts
+import { createAbortController } from '@rtorcato/js-common/abortController'
+
+const { controller, signal } = createAbortController()
+
+const result = await retry(() => fetch('/api/report', { signal }), {
+  shouldRetry: () => !signal.aborted,
+})
+```
+
+## See also
+
+- [promises](../modules/promises.md) — delay, timeout and settle helpers
+- [try](../modules/try.md) — `Result` values instead of thrown exceptions
+- [numbers](../modules/numbers.md) — sum, average, clamp, roundTo
+- [abortController](../modules/abortController.md) — cancel in-flight work with an `AbortSignal`
+- [Debounce a search input](./debounce-a-search-input.md)

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -10,6 +10,20 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: 'category',
+			label: 'Recipes',
+			// Pinned to the index so the category label itself is a landing page,
+			// and so index is not repeated inside the list below.
+			link: { type: 'doc', id: 'recipes/index' },
+			items: [
+				'recipes/format-date-for-locale',
+				'recipes/debounce-a-search-input',
+				'recipes/parse-untrusted-json',
+				'recipes/generate-a-unique-slug',
+				'recipes/retry-with-exponential-backoff',
+			],
+		},
+		{
+			type: 'category',
 			label: 'CLI',
 			items: ['guides/cli'],
 		},


### PR DESCRIPTION
Five cookbook pages that compose two or more modules each: locale date
formatting, debounced search, untrusted JSON parsing, unique slugs, and
retry with exponential backoff. Each page carries the full, copy-pasteable
code plus the caveats that matter (region-less detectLanguage, stale
responses, JSON null vs invalid, DB-level slug uniqueness, idempotency).

Surfaced through a pinned Recipes category in the sidebar and a link from
the homepage Next steps.

Closes #85
