### PR TITLE
ci: stop semantic-release pushing the release commit to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ coverage/
 # Design handoff bundles (reference material, applied to apps/docs — not shipped)
 design_handoff_docusaurus_redesign*/
 FIX-duplicate-route.md
+.claude/ai-loop-status

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,6 +1,15 @@
 import preset from '@rtorcato/repo-tooling/semantic-release/github'
 
+// The `code-scanning-main` ruleset rejects any push to main that lacks CodeQL
+// results, which a commit created seconds earlier can never have. Dropping
+// @semantic-release/git means no push-back to main; tag, npm publish and the
+// GitHub release are unaffected.
+const plugins = preset.plugins.filter(
+	(plugin) => (Array.isArray(plugin) ? plugin[0] : plugin) !== '@semantic-release/git'
+)
+
 export default {
 	...preset,
+	plugins,
 	repositoryUrl: 'https://github.com/rtorcato/js-common.git',
 }


### PR DESCRIPTION
## Why

Releases have been failing since at least 2026-08-08 (`be34830`), and again on `fc4692d` today. Every build and test job passes; only `release` fails:

```
git push --tags https://github.com/rtorcato/js-common.git HEAD:main
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Code scanning is waiting for results from CodeQL for the commit ad0c47c.
 ! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

The `code-scanning-main` ruleset (`~DEFAULT_BRANCH`, rule `code_scanning`, no bypass actors) requires CodeQL results for any push to `main`. `@semantic-release/git` creates a version + CHANGELOG commit and pushes it seconds later, so results cannot exist yet.

This is a deadlock, not a race: the commit must exist on the remote to be scanned, and must be scanned to be pushed. Retrying can never help.

It went unnoticed because every merge since `v2.8.2` was a `test:` commit, which correctly produces no release. `fc4692d` is the first commit that should have released — it carries a `BREAKING CHANGE:` footer, so `v3.0.0` is currently pending and unpublished.

## What this does

Filters `@semantic-release/git` out of the preset's plugin list in this repo's own `release.config.mjs`. Nothing else changes:

| Still works | Because |
|---|---|
| npm publish | `@semantic-release/npm`, unaffected |
| Git tag | Tags aren't covered by this branch ruleset |
| GitHub Release + notes | `@semantic-release/github`, unaffected |

**Trade-off:** `package.json`'s `version` and `CHANGELOG.md` are no longer committed back to `main`. npm and the GitHub Release become the source of truth for what shipped. This is the documented recommendation for repos with protected default branches.

## Alternatives rejected

- **Bypass actor on the ruleset** — a PAT can't be scoped as a bypass actor, so the only option covering `RELEASE_TOKEN` is the admin *role*, which would grant permanent code-scanning bypass to every admin on every direct push to `main`.
- **Disabling the ruleset** — drops the code-scanning gate for human PRs too.
- **Fixing `@rtorcato/repo-tooling`'s shared preset** — correct long-term, since every repo on that preset has the same latent breakage the moment it gets a code-scanning ruleset, but out of scope here. Worth its own issue.

## Also

Repairs `.gitignore`, whose last line (`FIX-duplicate-route.md`) had no trailing newline — an append had concatenated onto it and silently un-ignored that file.

## Verification

```
$ node --input-type=module -e "import c from './release.config.mjs'; \
    console.log(c.plugins.map(x=>Array.isArray(x)?x[0]:x))"
[ '@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator',
  '@semantic-release/github', '@semantic-release/changelog', '@semantic-release/npm' ]

$ git check-ignore -v .claude/ai-loop-status FIX-duplicate-route.md
.gitignore:48:.claude/ai-loop-status  .claude/ai-loop-status
.gitignore:47:FIX-duplicate-route.md  FIX-duplicate-route.md
```

Merging this should let the pending `v3.0.0` publish on the next run.