### PR TITLE
ci: gate releases behind an approval environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,10 @@ jobs:
 
     release:
         runs-on: ubuntu-latest
+        # Merging and publishing are otherwise the same event, so a PR title that
+        # hides a BREAKING CHANGE footer in its body can ship a major unattended.
+        # The environment holds this job until a human approves it.
+        environment: release
         needs: [dependencies, lint, typecheck, test, build, check-skip]
         if: needs.check-skip.outputs.should-skip != 'true' && github.ref == 'refs/heads/main' && github.event_name == 'push'
         steps:
@@ -287,3 +291,25 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
               run: npx semantic-release
+
+            # Releases failed silently from 2026-08-08 to 2026-08-11 because nothing
+            # surfaced the failure — every merge in between was a `test:` commit that
+            # correctly produced no release, so the breakage stayed invisible.
+            - name: 🔔 Report release failure
+              if: failure()
+              uses: actions/github-script@v8
+              with:
+                  script: |
+                      await github.rest.issues.create({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        title: `Release failed on ${context.sha.slice(0, 7)}`,
+                        body: [
+                          `The \`release\` job failed on \`${context.sha}\`.`,
+                          '',
+                          `[View the run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                          '',
+                          'Nothing was published. Releases stay blocked until this is fixed.',
+                        ].join('\n'),
+                        labels: ['bug'],
+                      })


### PR DESCRIPTION
## Why

Merging to `main` and publishing to npm were the same event, so **every merge decision was secretly a release decision**.

PR #149 demonstrated the risk. Its title was `fix(types): return the wrapper type from debounce/throttle…` — which reads as a patch. Its *body* carried:

```
BREAKING CHANGE: `debounce` and `throttle` no longer claim to return the
wrapped function's return type...
```

`squash_merge_commit_message` is `COMMIT_MESSAGES`, so that footer reached `main` verbatim. Two agent reviews passed (both correct — the change *is* right and *is* breaking), auto-merge fired, and an unattended `v3.0.0` publish queued. The release run was cancelled with seconds to spare.

Nothing about the review was wrong. The coupling was wrong.

## What this does

The `release` job now declares `environment: release`, and that environment has a required reviewer. CI still performs the release — nothing publishes from a laptop, no ruleset is bypassed, `RELEASE_TOKEN` is unchanged. The job just pauses until approved, and the pending-approval screen names the version about to ship.

Merging becomes ordinary. Releasing becomes deliberate.

The environment is already created:

```
$ gh api repos/rtorcato/js-common/environments/release
{"name":"release","protection_rules":[{"reviewers":["rtorcato"],"type":"required_reviewers"}]}
```

## Also: release failure alerting

Releases had been failing since **2026-08-08** (`be34830`) with `GH013: Repository rule violations` and nobody knew. It stayed invisible because every merge between then and now was a `test:` commit, which correctly produces no release — so there was no "missing release" to notice.

A `if: failure()` step now opens an issue naming the SHA and linking the run.

## Verification

`fc4692d`'s `BREAKING CHANGE:` footer is already on `main`, so `v3.0.0` is genuinely pending. After this and #153 land:

1. The `release` job should reach **Review pending** rather than running.
2. On approval, `npm view @rtorcato/js-common version` → `3.0.0`, and tag `v3.0.0` exists.

That makes the first use of this gate a real release rather than a drill.

## Note

Depends on #153 to actually succeed — that one removes `@semantic-release/git`, which is what currently gets rejected by the `code-scanning-main` ruleset. This PR controls *when* a release runs; #153 makes it able to finish. Either order merges safely.