### PR TITLE
ci: run checks on merge_group so the merge queue can be enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
         branches: [main, master]
     pull_request:
         branches: [main, master]
+    # Required for GitHub merge queue. Without it, checks never run against the
+    # merge group and every queued PR waits forever on contexts that cannot arrive.
+    merge_group:
     workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Prerequisite for turning on GitHub's merge queue. **Merges nothing on its own** — three lines of trigger config.

## Why

```
$ gh api repos/rtorcato/js-common/branches/main/protection
{"strict": true, "queue": null, "contexts": 5}
```

`strict: true` means branches must be up to date before merging, and there's no queue to manage that. With four PRs open, every merge invalidates the other three and each needs a `gh pr update-branch` — which is precisely the churn we hit today across #150, #151, #152 and #153.

## Why this must land before the queue is enabled

`ci.yml` had no `merge_group` trigger. Enabling the queue first would mean the five required contexts (`lint`, `typecheck`, `build`, `test (22)`, `test (24)`) **never report against the merge group**, so every queued PR would wait forever on checks that cannot arrive — a deadlock that looks like slowness.

## Why it's a no-op until then

Checked each gate against a `merge_group` event:

| Job | Behaviour on `merge_group` |
|---|---|
| `check-skip` | Reads `github.event.head_commit.message`, **empty** for this event → regex can't match → `should-skip=false` |
| `lint`, `typecheck`, `test`, `build`, `docs-build` | Gated only on `should-skip`, so they run — which is the point |
| `commitlint` | `github.event_name == 'pull_request'`, so skipped. Not a required check |
| `release` | `github.event_name == 'push'`, so skipped. Correct — the queue must not publish |

## After this merges

```bash
# enable the queue on main, then drop strict — the queue guarantees
# up-to-dateness itself, making the setting redundant churn
```

I've deliberately **not** made that settings change yet, since doing it before this merges is the deadlock above.

Once the queue is on, the loop's Pass 1 collapses from bespoke merge-ordering logic to "enqueue or report".