### PR TITLE
docs: reconcile TODO.md against actual issue state

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,26 +4,20 @@ Index of open work for `@rtorcato/js-common`. Each row links to a GitHub issue �
 
 ## Documentation
 
-- [x] [#82](https://github.com/rtorcato/js-common/issues/82) — Runnable examples on every function (input → output snippets; stretch: live playground)
-- [ ] [#83](https://github.com/rtorcato/js-common/issues/83) — Module overview prose, not just tables (when to reach for it + design rationale)
-- [x] [#84](https://github.com/rtorcato/js-common/issues/84) — "See also" cross-links between related modules
-- [x] [#85](https://github.com/rtorcato/js-common/issues/85) — Recipes / cookbook section (task-oriented pages composing multiple modules)
 - [ ] [#86](https://github.com/rtorcato/js-common/issues/86) — OG/social card images, custom 404, `og:image` metadata
-- [x] [#87](https://github.com/rtorcato/js-common/issues/87) — Surface migration page from homepage hero
-- [ ] [#74](https://github.com/rtorcato/js-common/issues/74) — README references undefined export `validateEmail`
-- [ ] [#77](https://github.com/rtorcato/js-common/issues/77) — Add "Related packages" section linking browser-common and js-tooling to README
-- [ ] [#72](https://github.com/rtorcato/js-common/issues/72) — Cross-link sibling repos (browser-common, js-tooling, swift-common) from docs
-- [ ] [#81](https://github.com/rtorcato/js-common/issues/81) — Add swift-common to sibling projects (homepage + footer)
+- [ ] [#103](https://github.com/rtorcato/js-common/issues/103) — Consume `@rtorcato/shared-docs` for the sibling-family list
+- [ ] [#124](https://github.com/rtorcato/js-common/issues/124) — Sync sibling family (db-x added, js-tooling → repo-tooling)
+- [ ] [#125](https://github.com/rtorcato/js-common/issues/125) — Adopt the family brand assets (banner, social card, favicon)
 
-## Tests
+## Features
 
-- [ ] [#76](https://github.com/rtorcato/js-common/issues/76) — Extend `.test-d.ts` coverage to generic helpers (debounce, pick/omit, groupBy, retry, timeout, requireOptional)
-- [ ] [#78](https://github.com/rtorcato/js-common/issues/78) — Expand fast-check property tests to objects/promises/json/math
+- [ ] [#95](https://github.com/rtorcato/js-common/issues/95) — In-repo AI skill (Claude marketplace + `AGENTS.md`) + docs install
 
 ## Bugs
 
-- [ ] [#73](https://github.com/rtorcato/js-common/issues/73) — `pino-pretty` missing from `optionalDependencies` (logger fails in dev)
+- [ ] [#130](https://github.com/rtorcato/js-common/issues/130) — Commits mis-attributed to a placeholder git identity
 
 ## Chores
 
-- [ ] [#75](https://github.com/rtorcato/js-common/issues/75) — Decide fate of commented type re-export in `src/types/index.d.ts`
+- [ ] [#91](https://github.com/rtorcato/js-common/issues/91) — Roadmap milestones (incl. beta) + release docs/README checklist
+- [ ] [#109](https://github.com/rtorcato/js-common/issues/109) — Migrate npm publishing to OIDC trusted publishing; remove `NPM_TOKEN`


### PR DESCRIPTION
Nine of the ten rows pointed at issues that are already closed. Removed
every closed row (per the file's own header, closed items live in git log
and the changelog) and added the open issues that were missing: #91, #95,
#103, #109, #124, #125, #130.

Closes #159
