### PR TITLE
docs: consume @rtorcato/shared-docs for the sibling-family list

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -1,21 +1,13 @@
 import type * as Preset from '@docusaurus/preset-classic'
 import type { Config } from '@docusaurus/types'
+import { GITHUB_PROFILE, projectFamilyItems } from '@rtorcato/shared-docs'
 import { themes as prismThemes } from 'prism-react-renderer'
 
-// The @rtorcato open-source family. Surfaced as a navbar "Projects" dropdown
-// (Docusaurus renders navbar items in the mobile menu too) and in the footer,
-// so every sibling site cross-links to the rest. Keep in sync across repos.
-const GITHUB_PROFILE = 'https://github.com/rtorcato'
-const PROJECT_FAMILY = [
-	{ label: 'js-common', href: 'https://rtorcato.github.io/js-common/' },
-	{ label: 'api-common', href: 'https://rtorcato.github.io/api-common/' },
-	{ label: 'browser-common', href: 'https://rtorcato.github.io/browser-common/' },
-	{ label: 'db-common', href: 'https://rtorcato.github.io/db-common/' },
-	{ label: 'cf-common', href: 'https://rtorcato.github.io/cf-common/' },
-	{ label: 'react-common', href: 'https://github.com/rtorcato/react-common' },
-	{ label: 'swift-common', href: 'https://rtorcato.github.io/swift-common/' },
-	{ label: 'repo-tooling', href: 'https://rtorcato.github.io/repo-tooling/' },
-]
+// The @rtorcato open-source family, from the single source of truth in
+// @rtorcato/shared-docs. Surfaced as a navbar "Projects" dropdown (Docusaurus
+// renders navbar items in the mobile menu too) and in the footer, so every
+// sibling site cross-links to the rest.
+const PROJECT_FAMILY = projectFamilyItems()
 
 const config: Config = {
 	title: 'js-common',

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -29,6 +29,7 @@
 		"@docusaurus/tsconfig": "^3.8.1",
 		"@docusaurus/types": "^3.8.1",
 		"@playwright/test": "^1.60.0",
+		"@rtorcato/shared-docs": "github:rtorcato/shared-docs",
 		"@types/react": "^19.0.0",
 		"docusaurus-plugin-typedoc": "^1.4.2",
 		"typedoc": "^0.28.19",

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import Link from '@docusaurus/Link'
 import useBaseUrl from '@docusaurus/useBaseUrl'
+import { siblings } from '@rtorcato/shared-docs'
 import Layout from '@theme/Layout'
 import clsx from 'clsx'
 import { type ReactElement, useEffect, useState } from 'react'
@@ -337,34 +338,7 @@ function Categories(): ReactElement {
 	)
 }
 
-type Sibling = {
-	name: string
-	tagline: string
-	href: string
-	dest: 'Docs' | 'GitHub'
-}
-
-const SIBLINGS: Sibling[] = [
-	{
-		name: '@rtorcato/browser-common',
-		tagline: 'Small, tree-shakeable TypeScript wrappers around 40+ browser Web APIs.',
-		href: 'https://rtorcato.github.io/browser-common/',
-		dest: 'Docs',
-	},
-	{
-		name: '@rtorcato/repo-tooling',
-		tagline:
-			'Shared Biome, TypeScript, Vitest and semantic-release presets that power the @rtorcato/* family.',
-		href: 'https://rtorcato.github.io/repo-tooling/',
-		dest: 'Docs',
-	},
-	{
-		name: 'rtorcato/swift-common',
-		tagline: 'Common Swift utilities for Apple platforms — Foundation Core + SwiftUI UI.',
-		href: 'https://rtorcato.github.io/swift-common/',
-		dest: 'Docs',
-	},
-]
+const SIBLINGS = siblings('@rtorcato/js-common')
 
 function Siblings(): ReactElement {
 	return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.62.1
+      '@rtorcato/shared-docs':
+        specifier: github:rtorcato/shared-docs
+        version: https://codeload.github.com/rtorcato/shared-docs/tar.gz/5fb0ae8ff63da6dcc027b2931ee7df3f7a48ce60(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.18
@@ -3027,6 +3030,14 @@ packages:
         optional: true
       vitest:
         optional: true
+
+  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/5fb0ae8ff63da6dcc027b2931ee7df3f7a48ce60':
+    resolution: {gitHosted: true, integrity: sha512-AmENptbpXoosikICI9c7ZPgzuhZIygdMgUIIImCA9C3gK8/hYtYKtupNSwSsertxa/rVCeK0pdw4vgAO+J+vpA==, tarball: https://codeload.github.com/rtorcato/shared-docs/tar.gz/5fb0ae8ff63da6dcc027b2931ee7df3f7a48ce60}
+    version: 1.2.0
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -12190,6 +12201,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/5fb0ae8ff63da6dcc027b2931ee7df3f7a48ce60(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@semantic-release/changelog@7.0.0(semantic-release@25.0.9(supports-color@8.1.1)(typescript@6.0.3))':
@@ -12759,7 +12775,7 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)


### PR DESCRIPTION
Migrates the docs site to the shared sibling-family list in [@rtorcato/shared-docs](https://github.com/rtorcato/shared-docs), removing the locally duplicated family data.

## Changes

- Added `@rtorcato/shared-docs` as a dev dependency of `apps/docs` (git dependency — not on npm; its `dist/` is committed, so there is no install-time build step).
- `apps/docs/docusaurus.config.ts`: the local `PROJECT_FAMILY` array is now `projectFamilyItems()`, and `GITHUB_PROFILE` is imported from the package instead of being declared locally. Both navbar-dropdown and footer consumers are unchanged.
- `apps/docs/src/pages/index.tsx`: the local `Sibling` type and `SIBLINGS` array are now `siblings('@rtorcato/js-common')`.
- No local `family.ts` existed; those two arrays were the only inline family data.

## Rendered output differs — expected

The shared list is ahead of the local copies, so the nav dropdown, footer column and sibling grid now also include `supabase-common` and `db-x`, and pick up the `js-tooling` → `repo-tooling` rename. This is the point of the migration, not a regression.

## Verification

- `pnpm --filter ./apps/docs build` succeeds. Inspecting the built `index.html`: the nav dropdown and footer render all family entries plus "All on GitHub →", and the sibling grid renders 9 cards with `@rtorcato/js-common` correctly excluded.
- `pnpm typecheck` and `pnpm check` pass (also enforced by the pre-commit hook).
- `pnpm --filter ./apps/docs typecheck` fails on a pre-existing `TS5101 baseUrl is deprecated` error from `@docusaurus/tsconfig`; confirmed identical on `main` without these changes.

Shared components (InstallTabs + the mobile-sidebar swizzles) are a later phase and out of scope here.

Closes #103