### PR TITLE
docs: add in-repo AI skill distribution (Claude marketplace + AGENTS.md)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "js-common",
+  "owner": {
+    "name": "Richard Torcato",
+    "email": "rtorcato@me.com"
+  },
+  "description": "Claude Code skill for @rtorcato/js-common — tree-shakeable TypeScript utilities across 46 subpath modules.",
+  "plugins": [
+    {
+      "name": "js-common",
+      "source": "./",
+      "description": "Teaches Claude to use @rtorcato/js-common correctly: subpath imports, which same-named helper belongs to which module, the three error idioms, and the Node-only modules."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "js-common",
+  "version": "1.0.0",
+  "description": "Teaches Claude to use @rtorcato/js-common correctly: subpath imports, which same-named helper belongs to which module, the three error idioms, and the Node-only modules.",
+  "author": {
+    "name": "Richard Torcato",
+    "email": "rtorcato@me.com",
+    "url": "https://github.com/rtorcato"
+  },
+  "homepage": "https://rtorcato.github.io/js-common/",
+  "repository": "https://github.com/rtorcato/js-common",
+  "license": "MIT",
+  "keywords": ["typescript", "utilities", "nodejs", "tree-shaking", "esm"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,11 @@ jobs:
             - name: 🔍 Run linting
               run: pnpm run check
 
+            # AGENTS.md is generated from skills/js-common/SKILL.md — fail the PR
+            # rather than let the two copies of the agent guidance drift apart.
+            - name: 🤖 Check AGENTS.md is in sync with SKILL.md
+              run: node scripts/sync-agents.mjs --check
+
     commitlint:
         runs-on: ubuntu-latest
         needs: [dependencies, check-skip]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+<!-- Generated from skills/js-common/SKILL.md by scripts/sync-agents.mjs — do not edit by hand; run `pnpm sync:agents`. -->
+
+# Using @rtorcato/js-common
+
+`@rtorcato/js-common` is a tree-shakeable, ESM-only utility library for Node.js >= 22 (TypeScript-first, JSDoc on every public API). One subpath export per concern — 46 of them. The package root is intentionally empty.
+
+## Rules
+
+1. **Import from the subpath, never the package root.** The root export has no runtime code at all, so a root import gets you nothing.
+
+   ```ts
+   // ✅ do
+   import { slugify } from '@rtorcato/js-common/strings'
+   // ❌ don't — the root export is empty by design
+   import { slugify } from '@rtorcato/js-common'
+   ```
+
+2. **The same name can exist in more than one module — pick by module, not by name.** Check this list before importing:
+
+   | Name | Modules | Difference |
+   |---|---|---|
+   | `roundTo` | `numbers`, `currency` | `currency` defaults to 2 decimals |
+   | `formatDate` | `date`, `formatting` | both take a `Date`; `date` is the date-utilities home |
+   | `formatTime` | `time`, `formatting` | `time` also parses/diffs times |
+   | `formatNumber` | `formatting`, `i18n` | `i18n` is locale-driven |
+   | `once` | `functions`, `events` | `functions` = call-once wrapper; `events` = one-shot DOM listener |
+   | `escapeHtml` / `unescapeHtml` | `strings`, `html` | identical intent; `html` also has `stripHtmlTags`, `strings` has `stripHtml` |
+   | `sanitizeString` | `strings`, `security` | `security` is the one to use on untrusted input |
+   | `pluralize` | `strings`, `i18n` | `i18n` is locale-aware |
+   | `randomString` | `strings`, `random` | `strings` requires an explicit charset |
+   | `secondsBetween` | `time`, `datetime` | equivalent |
+   | `isBoolean` | `boolean`, `validation` | `validation` is a type guard |
+   | `getProcessUptime` | `node`, `process` | equivalent |
+
+3. **Three different error idioms — don't mix them up.**
+
+   ```ts
+   // Result object — preferred for new code
+   import { tryCatch } from '@rtorcato/js-common/try'
+   const { data, error } = await tryCatch(() => fetchData())
+
+   // Go-style tuple: [error, data] — error FIRST
+   import { to } from '@rtorcato/js-common/promises'
+   const [err, value] = await to(fetchData())
+
+   // Swallows the error and returns a fallback — only when the fallback is genuinely safe
+   import { tryWithFallback } from '@rtorcato/js-common/errors'
+   const rows = await tryWithFallback(() => fetchRows(), [])
+   ```
+
+   `tryCatch` in `errors` was renamed to `tryWithFallback` in 2.0; `tryCatch` now means the Result helper in `try`.
+
+4. **Node-only modules.** `crypto`, `security`, and `file` import `node:crypto` / `node:fs`; `logger` uses pino. Don't ship these to a browser bundle. `events` is the opposite — it wraps DOM `EventTarget` and is browser-only. `os`, `process`, `node`, and `system` probe for `process` / `window` and degrade rather than throw.
+
+5. **`./types` is types-only.** It has a `types` field and no `import` field on purpose — use it for `import type { Prettify, Merge } from '@rtorcato/js-common/types'` only.
+
+6. **Some helpers need a peer input you must supply.** `convertCurrency(amount, rate)` takes the rate — the library does no FX lookup. `checkEnv(schema)` needs a Zod object schema and throws with the list of missing keys.
+
+## Module → exports
+
+Import from `@rtorcato/js-common/<module>`.
+
+| Module | Exports |
+|---|---|
+| abortController | createAbortController, abortPromise, withAbort, abortAfter |
+| arrays | first, last, unique, flatten, chunk, compact, shuffle, groupBy |
+| boolean | toBoolean, isBoolean, xor, and, or, not |
+| colors | randomColor, matchingTextColor, hexToRgb, rgbToHex, isValidHex, darken, lighten |
+| console | disableConsole, clearConsole |
+| crypto | hashString, randomHex, hmacHash, base64Encode, base64Decode |
+| currency | getCurrencySymbol, getCurrencyName, getCurrencyLocale, formatPrice, formatPriceCompact, parsePrice, parseCurrencyString, convertCurrency, isValidCurrencyCode, isValidCurrency, roundTo |
+| date | today, parseDate, formatDate, daysBetween, diffInHours, diffInMinutes, isLeapYear, addDays, subDays, addMonths, getDayOfWeek, startOfDay, endOfDay, isWeekend, isSameDay, isToday, formatRelative |
+| datetime | nowIso, parseIsoDateTime, formatDateTimeLocal, getTimezoneOffset, toUtcDate, unixTimestamp, unixMillis, secondsBetween, getIsoWeek, getIsoWeekInfo |
+| emails | isValidEmail, normalizeEmail, maskEmail, getEmailDomain, isFreeEmailProvider |
+| env | getENV, isDev, isProd, isTest, getNodeEnv, checkEnv, RootApiEnvSchema |
+| errors | createCustomError, isErrorName, getErrorMessage, assert, tryWithFallback |
+| events | on, emit, once, preventDefault, stopPropagation |
+| fetch | fetchWithTimeout, postJson, getJson, fetchText, handleApiError |
+| file | readFileAsString, writeFileAsString, fileExists, deleteFile, getFileExtension |
+| formatting | padZero, formatNumber, formatPercent, formatDate, formatTime, formatDateTime |
+| functions | once, debounce, throttle, compose, pipe |
+| geometry | distance2D, midpoint2D, angle2D, pointInRect, rectsOverlap, polygonArea |
+| html | escapeHtml, unescapeHtml, stripHtmlTags, textToHtml, containsHtml |
+| i18n | detectLanguage, formatNumber, formatDateI18n, t, pluralize |
+| interval | runInterval, clearIntervalById |
+| json | safeJsonParse, safeJsonStringify, isValidJson, deepCloneJson |
+| logger | logger (pino instance — pretty in dev, JSON in prod) |
+| logging | logWithTimestamp, info, warn, error, captureConsole, ConsoleLevel |
+| maps | invertMap, mapValues, mergeMaps, objectToMap, mapToObject |
+| math | add, subtract, multiply, divide |
+| mime-types | lookup, types, extensions, mimeTypes |
+| node | nodeVersionCheck, getNodeMajorVersion, isNode, requireOptional, getProcessUptime |
+| numbers | getRandomInt, getRandomFloat, clamp, roundTo, isFiniteNumber, isInteger, between, sum, average, mod, min, max |
+| objects | isPlainObject, deepMerge, omit, pick, deepClone |
+| os | getOsPlatform, getOsRelease, getOsArch, getHomeDir, getTmpDir |
+| process | getProcessId, getProcessUptime, getCwd, getProcessPlatform, exitProcess, isCI |
+| promises | delay, to, withTimeout, all, allSettled, race |
+| random | randomInt, randomFloat, randomBool, randomElement, randomString |
+| regex | escapeRegExp, testRegex, matchAll, replaceAllRegex, splitByRegex |
+| security | sanitizeString, isStrongPassword, generateSecureToken |
+| sets | union, intersection, difference, isSubset, isSuperset, setToArray, arrayToSet |
+| sleep | sleep, sleepSync, sleepRandom, sleepWithAbort |
+| strings | titleCase, capitalize, camelCase, kebabCase, snakeCase, truncate, padStart, padEnd, randomString, replaceString, sanitizeString, reverse, slugify, words, wordCount, escapeHtml, unescapeHtml, stripHtml, pluralize, ordinalize, isBlank, mask, template |
+| system | isMacOs, isWindows, isLinux, isIOS, isAndroid, getPlatform, isTouchDevice |
+| time | nowTime, nowTimeShort, parseTime, formatTime, secondsBetween, pad2 |
+| try | tryCatch, isSuccess, Result, Success, Failure |
+| types | Prettify, Merge (types only) |
+| url | isValidUrl, getQueryParams, setQueryParam, removeQueryParam, joinUrl, getHostname |
+| uuid | getUUID, getUUIDv7, getShortUUID, toShortUUID, fromShortUUID, isUUID, isUUIDv4, isNilUUID, getUUIDVersion, getNilUUID, uuidToBytes, bytesToUUID |
+| validation | isDefined, isString, isNumber, isBoolean, isArray, isObject, isEmail, isUrl |
+
+## CLI
+
+The package also ships a binary for shell use:
+
+```bash
+npx @rtorcato/js-common@latest date today
+npx @rtorcato/js-common@latest math sum 1 2 3
+npx @rtorcato/js-common@latest text capitalize "hello world"
+```
+
+See [CLI.md](https://github.com/rtorcato/js-common/blob/main/CLI.md) for the full command list.
+
+For full signatures and examples, see <https://rtorcato.github.io/js-common/>.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,26 @@ A comprehensive set of common JavaScript and TypeScript utilities for Node.js pr
 npm install @rtorcato/js-common
 ```
 
-## Agent skill
+## Use with AI
 
-An agent skill lives in [`skills/js-common`](./skills/js-common/SKILL.md) — it teaches an AI coding agent the subpath-import rules, which modules are Node-only, and the full module → exports map. Install it with the [`skills`](https://www.npmjs.com/package/skills) CLI:
+An agent skill lives in [`skills/js-common`](./skills/js-common/SKILL.md) — it teaches an AI coding agent the subpath-import rules, which same-named helper belongs to which module, the three error idioms, which modules are Node-only, and the full module → exports map.
+
+**Claude Code** — this repo is its own plugin marketplace:
+
+```
+/plugin marketplace add rtorcato/js-common
+/plugin install js-common@js-common
+```
+
+**Cursor, Copilot, Codex and other tools** — read [`AGENTS.md`](./AGENTS.md), the cross-tool convention file. It carries the same guidance and also ships in the npm tarball, so tools that scan `node_modules` find it at `node_modules/@rtorcato/js-common/AGENTS.md`.
+
+**Any tool the [`skills`](https://www.npmjs.com/package/skills) CLI supports:**
 
 ```bash
 npx skills add https://github.com/rtorcato/js-common --skill js-common
 ```
+
+`AGENTS.md` is generated from `SKILL.md` by `pnpm sync:agents`; CI fails if they drift. Edit `SKILL.md`, never `AGENTS.md`.
 
 ## Migrating from 1.x to 2.x
 

--- a/apps/docs/src/pages/index.module.css
+++ b/apps/docs/src/pages/index.module.css
@@ -311,6 +311,18 @@
 	color: var(--jc-text);
 }
 
+/* Use-with-AI install snippets */
+.aiCode {
+	margin: 12px 0 0;
+	padding: 12px 14px;
+	background: var(--jc-code-bg);
+	border: 1px solid var(--jc-border);
+	border-radius: 10px;
+	font: 500 12.5px / 1.7 var(--ifm-font-family-monospace);
+	color: var(--jc-text);
+	overflow: auto;
+}
+
 /* ---------- Responsive ---------- */
 @media (max-width: 996px) {
 	.pillarGrid {

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -392,6 +392,66 @@ function Siblings(): ReactElement {
 	)
 }
 
+type AiTarget = {
+	title: string
+	desc: ReactElement
+	code: string
+}
+
+const AI_TARGETS: AiTarget[] = [
+	{
+		title: 'Claude Code',
+		desc: <>The repo is its own plugin marketplace — add it, then install the skill.</>,
+		code: '/plugin marketplace add rtorcato/js-common\n/plugin install js-common@js-common',
+	},
+	{
+		title: 'Cursor, Copilot, Codex',
+		desc: (
+			<>
+				They read <code>AGENTS.md</code>. It ships in the npm tarball, so it is already in your{' '}
+				<code>node_modules</code>.
+			</>
+		),
+		code: 'node_modules/@rtorcato/js-common/AGENTS.md',
+	},
+	{
+		title: 'Anything else',
+		desc: <>Pull the skill into any tool the skills CLI supports.</>,
+		code: 'npx skills add https://github.com/rtorcato/js-common \\\n  --skill js-common',
+	},
+]
+
+function UseWithAI(): ReactElement {
+	return (
+		<section className={styles.section}>
+			<div className={styles.sectionHead}>
+				<div>
+					<h2 className={styles.h2}>Use with AI</h2>
+					<p className={styles.sub}>
+						One skill teaches your coding agent the subpath-import rules, the three error idioms and
+						which modules are Node-only.
+					</p>
+				</div>
+				<Link
+					className={styles.viewAll}
+					href="https://github.com/rtorcato/js-common/blob/main/AGENTS.md"
+				>
+					Read the rules →
+				</Link>
+			</div>
+			<div className={styles.catGrid}>
+				{AI_TARGETS.map((t) => (
+					<div key={t.title} className={styles.pillar}>
+						<div className={styles.pillarTitle}>{t.title}</div>
+						<div className={styles.pillarDesc}>{t.desc}</div>
+						<pre className={styles.aiCode}>{t.code}</pre>
+					</div>
+				))}
+			</div>
+		</section>
+	)
+}
+
 export default function Home(): ReactElement {
 	return (
 		<Layout
@@ -402,6 +462,7 @@ export default function Home(): ReactElement {
 				<Hero />
 				<Pillars />
 				<Categories />
+				<UseWithAI />
 				<Siblings />
 			</main>
 		</Layout>

--- a/package.json
+++ b/package.json
@@ -44,10 +44,12 @@
     "size": "size-limit",
     "benchmark": "node scripts/benchmark.mjs",
     "docs:generate": "node scripts/generate-module-docs.mjs",
+    "sync:agents": "node scripts/sync-agents.mjs",
     "commit": "cz",
     "================================================": ""
   },
   "files": [
+    "AGENTS.md",
     "CHANGELOG.md",
     "CONTRIBUTORS.md",
     "dist",

--- a/scripts/sync-agents.mjs
+++ b/scripts/sync-agents.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Regenerate AGENTS.md from the js-common SKILL.md body so the two can never
+ * drift. SKILL.md (with its YAML frontmatter) is the single source of truth;
+ * AGENTS.md is its frontmatter-stripped mirror for non-Claude AI tools.
+ *
+ *   node scripts/sync-agents.mjs           # write AGENTS.md
+ *   node scripts/sync-agents.mjs --check   # exit 1 if AGENTS.md is stale (used by CI)
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const SKILL = join(root, 'skills/js-common/SKILL.md')
+const AGENTS = join(root, 'AGENTS.md')
+
+const HEADER =
+	'<!-- Generated from skills/js-common/SKILL.md by scripts/sync-agents.mjs — do not edit by hand; run `pnpm sync:agents`. -->\n\n'
+
+// Strip the leading YAML frontmatter block, keep the markdown body.
+const body = readFileSync(SKILL, 'utf8').replace(/^---\n[\s\S]*?\n---\n+/, '')
+const expected = HEADER + body
+
+if (process.argv.includes('--check')) {
+	let current = ''
+	try {
+		current = readFileSync(AGENTS, 'utf8')
+	} catch {
+		// AGENTS.md missing → treat as stale below.
+	}
+	if (current !== expected) {
+		console.error('AGENTS.md is out of sync with SKILL.md — run `pnpm sync:agents`.')
+		process.exit(1)
+	}
+	console.log('AGENTS.md is in sync with SKILL.md.')
+} else {
+	writeFileSync(AGENTS, expected)
+	console.log('Wrote AGENTS.md from skills/js-common/SKILL.md')
+}


### PR DESCRIPTION
Closes #95

## Why `docs:` and not `feat:`

This ships **no runtime API** — not one line of `src/` changed. It adds plugin metadata, a generated markdown file, a build script, and docs. A `feat:` subject would cut a minor release through semantic-release and publish a version whose only change is documentation, so `docs:` is the honest type. One consequence worth naming: because this cuts no release, `AGENTS.md` will not appear in the npm tarball until the next release ships for another reason. That is the right trade — it is in the repo and on the docs site immediately, which is where agents look first.

## What's here

- **`.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`** — the repo is its own self-hosted marketplace, so there is no central repo to drift against:
  ```
  /plugin marketplace add rtorcato/js-common
  /plugin install js-common@js-common
  ```
- **Root `AGENTS.md`** — the cross-tool convention file Cursor, Copilot and Codex read. It is **generated** from `skills/js-common/SKILL.md` by `scripts/sync-agents.mjs` (ported from the same script in `rtorcato/browser-common`), and the CI lint job now runs `node scripts/sync-agents.mjs --check`, so the two copies of the guidance cannot silently diverge. `SKILL.md` stays the single source of truth; edit that, run `pnpm sync:agents`.
- **`AGENTS.md` added to `package.json` `files`** (alphabetically first) so tools that scan `node_modules` find it at `node_modules/@rtorcato/js-common/AGENTS.md`.
- **README** — the existing `## Agent skill` section was widened into `## Use with AI` covering all three install paths. No second, near-duplicate section was added.
- **Docs front page** — a new `UseWithAI` section between Categories and Siblings, with a card per install path. It reuses the existing `.section` / `.catGrid` / `.pillar` classes and adds exactly one new CSS rule (`.aiCode`).

`skills/js-common/SKILL.md` is **unchanged**. It was already complete and current — its 46-module table matches the 46 subpath `exports` keys in `package.json` exactly.

## Verification

| Check | Result |
|---|---|
| `claude plugin validate . --strict` | ✅ passes (the CLI was available locally; run against the worktree) |
| `pnpm check` (Biome) | ✅ 147 files, no fixes |
| `pnpm typecheck` | ✅ clean |
| `pnpm --filter @rtorcato/js-common-docs build` | ✅ compiled, static files generated |
| `node scripts/sync-agents.mjs --check` | ✅ in sync |

`.claude-plugin/` is **not** covered by the `!**/.claude` ignore in `biome.json` (glob segments match exactly), so both new JSON files are linted by Biome and pass.

## Merge note

`apps/docs/src/pages/index.tsx` is also touched by open PR #161 around the `SIBLINGS` array. This addition is deliberately placed **after** `Siblings()` ends, and nothing in that range was reformatted, so the two should merge cleanly without a rebase.

## Follow-up, out of scope

`.github/COPILOT.md` is stale — it references `attempt`, `trycatch`, `requireEnv` and `isEmpty`, none of which exist any more. It is exactly the drift the generated `AGENTS.md` is designed to prevent. Worth a separate issue to either regenerate it from `SKILL.md` too or delete it in favour of `AGENTS.md`.

---
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*