### PR TITLE
docs: mark the sibling-family sync complete in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,7 @@ Index of open work for `@rtorcato/js-common`. Each row links to a GitHub issue �
 ## Documentation
 
 - [ ] [#86](https://github.com/rtorcato/js-common/issues/86) — OG/social card images, custom 404, `og:image` metadata
-- [ ] [#103](https://github.com/rtorcato/js-common/issues/103) — Consume `@rtorcato/shared-docs` for the sibling-family list
-- [ ] [#124](https://github.com/rtorcato/js-common/issues/124) — Sync sibling family (db-x added, js-tooling → repo-tooling)
+- [x] [#124](https://github.com/rtorcato/js-common/issues/124) — Sync sibling family (db-x added, js-tooling → repo-tooling)
 - [ ] [#125](https://github.com/rtorcato/js-common/issues/125) — Adopt the family brand assets (banner, social card, favicon)
 
 ## Features


### PR DESCRIPTION
Verification-first issue: the family sync had already landed via #103, so this PR is deliberately one line rather than a manufactured diff.

## What was checked

**Item 1 — sibling cards + Projects pulldown.** Sourced entirely from `@rtorcato/shared-docs`; there is no inline list in this repo:

- `apps/docs/docusaurus.config.ts` → `projectFamilyItems()` feeds both the navbar "Projects" dropdown and the footer.
- `apps/docs/src/pages/index.tsx` → `siblings('@rtorcato/js-common')` feeds the sibling grid.

`pnpm-lock.yaml` pins shared-docs at `5fb0ae8`, which is that repo's current HEAD. Its `src/family.ts` already contains both `db-x` and `@rtorcato/repo-tooling`. No bump needed — the specifier is `github:rtorcato/shared-docs` and the pinned commit is current.

**Item 2 — local `js-tooling` references.** All already migrated:

| Surface | State |
|---|---|
| `package.json` devDependency | `@rtorcato/repo-tooling@^3.0.0` |
| `tsconfig.json`, `biome.json`, `vitest.config.mjs`, `commitlint.config.mjs`, `release.config.mjs`, `build.mjs` | all extend/import `@rtorcato/repo-tooling/*` |
| `pnpm-workspace.yaml`, `.github/dependabot.yml` | `@rtorcato/repo-tooling` |
| `README.md` "Related packages" | links `repo-tooling` |
| `.js-tooling.config.json` | never existed in this repo |

## What changed

`TODO.md` only:

- `#124` ticked `[x]`.
- `#103` row dropped — merged as `bb7fe2c` (PR #161) after the last reconcile pass (#160) wrote the file.

## Deliberately not changed

- **`CHANGELOG.md:214`** (`modernize CI/CD workflow with js-tooling structure`) — changelog entries are history and record the package's name at the time.
- **`--jt-*` CSS custom properties and `apps/docs/src/css/_jt-tokens.css`** — that filename and prefix are what `repo-tooling copy docusaurus-theme-tokens` emits upstream. Renaming them here would fork the copy from its source. If the prefix should change, it changes in repo-tooling first.
- **README "Related packages" does not gain `db-x`.** That list came from #77 as a curated two-item pointer to the siblings a js-common user would actually reach for, not a mirror of the family — the full family already renders on the docs homepage and in the nav from shared-docs.

Closes #124
