### PR TITLE
docs: add ROADMAP.md and a public-API release checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,12 @@ Fixes #<!-- issue number -->
 - [ ] I have added/updated JSDoc comments for new/modified functions
 - [ ] I have updated TypeScript definitions if needed
 
+### Public API changes only
+<!-- Skip this block for refactors, build/CI, and dependency bumps — see ROADMAP.md -->
+- [ ] Docs site updated (`apps/docs/docs/modules/`, plus a recipe if warranted)
+- [ ] README updated (module list + affected examples)
+- [ ] Relevant [`ROADMAP.md`](../ROADMAP.md) item ticked and the issue filed under its milestone
+
 ### Build & Dependencies
 - [ ] My changes don't introduce new dependencies unnecessarily
 - [ ] The build passes (`pnpm run build-prod`)

--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ pnpm --filter @rtorcato/js-common-docs build
 
 Live site: <https://rtorcato.github.io/js-common/>
 
+## Roadmap
+
+[ROADMAP.md](./ROADMAP.md) tracks the three stages — shipped 2.x modules, the beta npm preview, and the v1.0 stable API — each mirrored by a [GitHub milestone](https://github.com/rtorcato/js-common/milestones). It also carries the release checklist for any change that touches a public API.
+
 ## Contributing
 
 Contributions are welcome! Please read [CONTRIBUTORS.md](./CONTRIBUTORS.md) for guidelines.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,47 @@
+# Roadmap
+
+Where `@rtorcato/js-common` is going, and what "done" means for each stage. Each
+section maps 1:1 to a [GitHub milestone](https://github.com/rtorcato/js-common/milestones) —
+the milestone is where the individual issues live, this file is the at-a-glance view.
+Day-to-day open work is in [TODO.md](./TODO.md).
+
+## [v2.x — Shipped modules](https://github.com/rtorcato/js-common/milestone/1) — done
+
+Everything already published to npm up to 2.8.2.
+
+- [x] ~47 tree-shakeable subpath modules (`strings`, `date`, `arrays`, `objects`, `crypto`, `fetch`, `validation`, …)
+- [x] CLI (`src/cli/`), built and shipped separately
+- [x] Biome + Vitest + Husky + semantic-release tooling
+- [x] Docusaurus docs site on GitHub Pages
+
+## [Beta — npm preview](https://github.com/rtorcato/js-common/milestone/2)
+
+The pre-stable line, published under a beta/next dist-tag for real-world feedback
+before the public surface is locked. **Breaking changes are still allowed here.**
+
+- [ ] Publish a `beta` dist-tag alongside `latest`
+- [ ] Shake out API rough edges reported against the preview
+- [ ] Settle the module boundaries — no more renames after this stage
+
+## [v1.0 — Stable API](https://github.com/rtorcato/js-common/milestone/3)
+
+The stable, documented public surface. After this, breaking changes only in a major.
+
+- [ ] A docs-site guide per module, not just generated API reference
+- [ ] README API reference in sync with the shipped exports
+- [ ] Bundle-size budget enforced in CI (`.size-limit.json`)
+
+> **Note on the version number.** `package.json` is already at 2.x, so "v1.0" here
+> names the *API stability* stage, not the semver number the release will carry.
+
+## Release checklist
+
+Version bumps are automated by semantic-release — never bump `package.json` by hand.
+This checklist covers what automation *can't* do. Any change that **adds or changes a
+public API** must also:
+
+- [ ] Update the docs site (`apps/docs/docs/modules/`, plus a recipe if the API deserves one)
+- [ ] Update the README — the module list under "Available Modules" and any affected example
+- [ ] Tick the relevant item in this file, and close the issue in its milestone
+
+Internal changes (refactors, build, CI, dependency bumps) don't need any of the above.

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO
 
-Index of open work for `@rtorcato/js-common`. Each row links to a GitHub issue — that's the source of truth, this file is the at-a-glance view. Closed items live in `git log` and the changelog.
+Index of open work for `@rtorcato/js-common`. Each row links to a GitHub issue — that's the source of truth, this file is the at-a-glance view. Closed items live in `git log` and the changelog. For the longer arc — the beta preview and the v1.0 stable API — see [ROADMAP.md](./ROADMAP.md).
 
 ## Documentation
 
@@ -19,5 +19,4 @@ Index of open work for `@rtorcato/js-common`. Each row links to a GitHub issue �
 
 ## Chores
 
-- [ ] [#91](https://github.com/rtorcato/js-common/issues/91) — Roadmap milestones (incl. beta) + release docs/README checklist
 - [ ] [#109](https://github.com/rtorcato/js-common/issues/109) — Migrate npm publishing to OIDC trusted publishing; remove `NPM_TOKEN`


### PR DESCRIPTION
Closes #91

## What

The three GitHub milestones were already created (in a prior attempt on this issue) and are live — `v2.x — Shipped modules` (closed), `Beta — npm preview`, `v1.0 — Stable API`. This PR is the file-side half.

- **`ROADMAP.md`** (new) — one section per milestone, each linking to it, plus the release checklist from the issue: any change that adds or changes a public API must update the docs site, update the README, and tick the roadmap/milestone item. Internal changes are explicitly exempt.
- **`README.md`** — a short `## Roadmap` section pointing at it, above Contributing.
- **`.github/pull_request_template.md`** — a "Public API changes only" checklist block, so the checklist is enforced where changes actually land.
- **`TODO.md`** — drops the now-closed #91 row and points at `ROADMAP.md` for the longer arc.

## Note for the reviewer

`package.json` is at **2.8.2**, so the `v1.0 — Stable API` milestone title is arguably a misnomer for this package — `v3.0` would match its actual version line. It's what the issue specified, so I left it alone and added a note in `ROADMAP.md` clarifying that "v1.0" names the API-stability stage rather than the semver number. **Flagged for the owner to retitle the milestone if they agree** — I did not retitle it.

Docs-only; no source, no build, no dependency changes.

---
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*