### PR TITLE
docs: add og:image metadata and a custom 404 page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@ Index of open work for `@rtorcato/js-common`. Each row links to a GitHub issue �
 
 ## Documentation
 
-- [ ] [#86](https://github.com/rtorcato/js-common/issues/86) — OG/social card images, custom 404, `og:image` metadata
 - [ ] [#103](https://github.com/rtorcato/js-common/issues/103) — Consume `@rtorcato/shared-docs` for the sibling-family list
 - [ ] [#124](https://github.com/rtorcato/js-common/issues/124) — Sync sibling family (db-x added, js-tooling → repo-tooling)
 - [ ] [#125](https://github.com/rtorcato/js-common/issues/125) — Adopt the family brand assets (banner, social card, favicon)

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -111,6 +111,11 @@ const config: Config = {
 	],
 
 	themeConfig: {
+		// Social card. Docusaurus turns this into og:image + twitter:image (absolute
+		// URLs), and already emits twitter:card=summary_large_image by default, so
+		// shared links render a preview card. Uses the existing 1774×887 banner until
+		// a purpose-built 1200×630 `img/og.png` is designed — see issue #86.
+		image: 'img/banner.png',
 		colorMode: {
 			defaultMode: 'dark',
 			respectPrefersColorScheme: true,

--- a/apps/docs/src/theme/NotFound/Content/index.tsx
+++ b/apps/docs/src/theme/NotFound/Content/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * Swizzled (eject) NotFound/Content — the body of the 404 page.
+ *
+ * The stock version is a dead end: a heading, "we could not find what you were
+ * looking for", and no way onward. This one keeps the same slot (the parent
+ * @theme/NotFound still supplies Layout + page metadata) and adds links back
+ * into the docs so a stale or mistyped URL lands somewhere useful.
+ */
+import Link from '@docusaurus/Link'
+import Heading from '@theme/Heading'
+import clsx from 'clsx'
+import type { ReactElement } from 'react'
+
+type Destination = {
+	to: string
+	label: string
+	desc: string
+}
+
+const DESTINATIONS: Destination[] = [
+	{ to: '/docs', label: 'Documentation', desc: 'Install, quick start, and guides.' },
+	{ to: '/docs/modules/overview', label: 'Modules', desc: 'Every module and what it covers.' },
+	{ to: '/docs/api', label: 'API reference', desc: 'Generated signatures for each export.' },
+]
+
+export default function NotFoundContent({ className }: { className?: string }): ReactElement {
+	return (
+		<main className={clsx('container margin-vert--xl', className)}>
+			<div className="row">
+				<div className="col col--8 col--offset-2">
+					<Heading as="h1" className="hero__title">
+						Page not found
+					</Heading>
+					<p>
+						That page doesn't exist — it may have moved when the docs were reorganised, or the link
+						that brought you here is out of date.
+					</p>
+					<p>
+						<Link className="button button--primary button--lg" to="/docs">
+							Go to the docs
+						</Link>
+					</p>
+					<ul>
+						{DESTINATIONS.map((destination) => (
+							<li key={destination.to}>
+								<Link to={destination.to}>{destination.label}</Link> — {destination.desc}
+							</li>
+						))}
+					</ul>
+					<p>
+						If a link on this site is broken,{' '}
+						<Link to="https://github.com/rtorcato/js-common/issues">open an issue</Link>.
+					</p>
+				</div>
+			</div>
+		</main>
+	)
+}


### PR DESCRIPTION
Closes #86

Scope is the code-side items only, per the scoping comment on the issue.

## What's here

- **`og:image` metadata** — `themeConfig.image` in `apps/docs/docusaurus.config.ts`. Docusaurus expands it to absolute `og:image` + `twitter:image` tags and already emits `twitter:card=summary_large_image`, so shared links render a preview card.
- **Custom 404** — swizzles `NotFound/Content` so a stale or mistyped URL offers routes back into the docs (`/docs`, `/docs/modules/overview`, `/docs/api`, plus an issue link) instead of dead-ending. The parent `@theme/NotFound` still supplies Layout and page metadata.
- **`TODO.md`** — drops the #86 row.

## Deliberate deviation

The issue asks for `static/img/og.png` (1200×630). No binary was generated — that's a design pass, tracked in #125. Wiring the config to a path that does not exist would ship `og:image` metadata resolving to a 404 for every shared link, so this points at the existing committed `img/banner.png` (1774×887), which renders a real large-summary card today. A code comment names `img/og.png` as the intended replacement; swapping it later is one line.

## Verification — stated plainly

- `biome check` clean on the changed files.
- `tsc --noEmit` in `apps/docs` passes (only a pre-existing `baseUrl` deprecation warning).
- **The 404 page has NOT been rendered end-to-end.** A full `docusaurus build` fails on `Module not found: Can't resolve '@rtorcato/shared-docs'` — that dependency isn't installed locally and the build fails the same way on `main`, so it is unrelated to this change. CI will be the first real render.

Titled `docs:` rather than `feat:` on purpose — nothing under `src/` changed, and `feat` as the squash subject would make semantic-release publish a new package version for a docs-site-only change.
