### PR TITLE
chore(tooling): close repo-tooling drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,49 +1,53 @@
-# Automated dependency updates with Dependabot
-# https://docs.github.com/en/code-security/dependabot
-
 version: 2
 updates:
-# Enable version updates for npm/pnpm
-- package-ecosystem: "npm"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: "monday"
-    time: "10:00"
-  open-pull-requests-limit: 5
-  assignees:
-  - "rtorcato"
-  commit-message:
-    prefix: "chore"
-    include: "scope"
-  # typedoc peers cap at TypeScript 6.0.x, so TS 7 breaks the docs API
-  # reference build. Drop this once typedoc 1.0 ships with TS 7 support.
-  ignore:
-  - dependency-name: "typescript"
-    versions: [">=7"]
-  # Group updates to reduce PR noise
-  groups:
-    development-dependencies:
-      patterns:
-      - "@types/*"
-      - "*eslint*"
-      - "*prettier*"
-      - "vitest*"
-      - "typescript"
-      - "@rtorcato/repo-tooling"
-      - "biome"
-      - "husky"
-      - "lint-staged"
-    production-dependencies:
-      exclude-patterns:
-      - "@types/*"
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+      time: "06:00"
+      timezone: Etc/UTC
+    # Let brand-new releases settle before opening a PR — keeps grouped bumps
+    # from tripping pnpm's minimumReleaseAge supply-chain check (a same-day
+    # release fails the frozen-lockfile install in CI).
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    assignees:
+      - "rtorcato"
+    commit-message:
+      prefix: chore
+      include: scope
+    # typedoc peers cap at TypeScript 6.0.x, so TS 7 breaks the docs API
+    # reference build. Drop this once typedoc 1.0 ships with TS 7 support.
+    ignore:
+      - dependency-name: "typescript"
+        versions: [">=7"]
+    groups:
+      # Safe tier: runtime + dev minor/patch auto-merge on green (see the
+      # dependabot-automerge workflow). Grouped so react/react-dom move together.
+      production-minor:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-minor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      # Majors batch into one PR per ecosystem — breaking by definition, so
+      # never auto-merged; triaged on the monthly cadence.
+      major-updates:
+        update-types:
+          - major
 
-# Monitor GitHub Actions
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "monthly"
-  commit-message:
-    prefix: "ci"
-  assignees:
-  - "rtorcato"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    assignees:
+      - "rtorcato"
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,14 @@ jobs:
                       node_modules
                   key: ${{ needs.dependencies.outputs.cache-key }}
 
+            # The cache above only carries the root node_modules, never
+            # apps/docs/node_modules. This job used to get away with that
+            # because pnpm auto-installed the missing workspace deps before
+            # running the script; with verifyDepsBeforeRun disabled it no
+            # longer does, so install explicitly like every other job.
+            - name: 📦 Install dependencies
+              run: pnpm install --frozen-lockfile
+
             - name: 📘 Build docs site
               run: pnpm --filter @rtorcato/js-common-docs build
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,1 @@
-
-# pnpm run typecheck
-# pnpm run lint
-# pnpm run test
-
-# pnpm run typecheck
-# pnpm run lint
+pnpm verify

--- a/.repo-tooling.json
+++ b/.repo-tooling.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://rtorcato.github.io/repo-tooling/schemas/lockfile.json",
+  "version": 2,
+  "config": {
+    "projectName": "@rtorcato/js-common",
+    "projectType": "library",
+    "typescript": {
+      "enabled": true,
+      "config": "base"
+    },
+    "linting": {
+      "tool": "biome",
+      "eslintConfig": "base"
+    },
+    "formatting": {
+      "tool": "biome"
+    },
+    "testing": {
+      "framework": "vitest",
+      "environment": "node"
+    },
+    "gitHooks": true,
+    "commitLint": true,
+    "semanticRelease": true,
+    "securityAutomation": true,
+    "bundler": "esbuild"
+  },
+  "writtenBy": "@rtorcato/repo-tooling@3.4.0",
+  "writtenAt": "2026-08-11T20:24:34.366Z"
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "docs:generate": "node scripts/generate-module-docs.mjs",
     "sync:agents": "node scripts/sync-agents.mjs",
     "commit": "cz",
+    "verify": "pnpm typecheck && pnpm check && pnpm exec vitest run",
     "================================================": ""
   },
   "files": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,8 @@ allowBuilds:
   sharp: true
 
 minimumReleaseAgeExclude:
-  - '@rtorcato/repo-tooling@3.0.0'
+  - '@rtorcato/*'
+
+# Don't re-verify node_modules on every script run — the check costs a
+# second per invocation and CI installs with --frozen-lockfile anyway.
+verifyDepsBeforeRun: false


### PR DESCRIPTION
`repo-tooling doctor` reported **5 drifts / 26 ok**. This closes the four that live in files. It now reports **33 ok, 2 drift** — and the two remaining are GitHub repo settings, already fixed out of band (see below).

## Changes

- **`pnpm-workspace.yaml`** — add `verifyDepsBeforeRun: false`, widen `minimumReleaseAgeExclude` to `'@rtorcato/*'` (drops the version-pinned `@rtorcato/repo-tooling@3.0.0` entry, which the wildcard covers).
- **`package.json`** — add the unified `verify` script (`typecheck && check && vitest run`).
- **`.husky/pre-push`** — run `pnpm verify`. The hook was **100% commented out**, so pushes were entirely unguarded. Verified live: this push ran the suite (388 tests) before completing.
- **`.github/dependabot.yml`** — adopt the canonical `production-minor` / `dev-minor` / `major-updates` grouping + the `dependabot-automerge` workflow. The generator overwrites wholesale, so the deliberate `typescript: >=7` ignore (typedoc peers cap at TS 6) and the `assignees` were restored on top.
- **`.repo-tooling.json`** — record the adopted presets so future `doctor` runs report intentional opt-outs as *declined* rather than *missing* (18 → 14 not-configured). `bundler` hand-corrected to `esbuild`; the generator inferred `tsup`, which this repo does not use.

## Deliberately not done

`fix husky` would replace the custom `.husky/pre-commit` with `npx lint-staged`. Left alone — its comment documents a real bug it fixes, where whole-tree formatting rewrote files *after* the checks and never re-staged them.

## Repo settings (applied via API, not in this diff)

- `main` branch protection: `required_status_checks.strict` `true` → `false` (strict blocks auto-merge until a PR is rebased; the five required contexts are unchanged).
- Actions: `can_approve_pull_request_reviews` `true` → `false`. `required_pull_request_reviews` left `null`.

## Verification

`pnpm verify` passes: clean typecheck, 152 files lint-clean, 388 tests.