### PR TITLE
chore(claude): symlink node_modules into agent worktrees + unblock .claude-only commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,5 +13,8 @@
         ]
       }
     ]
+  },
+  "worktree": {
+    "symlinkDirectories": ["node_modules"]
   }
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,10 +10,15 @@ pnpm run check
 # tree here used to rewrite files *after* the checks and never `git add` them,
 # so the commit could contain unformatted code while the working tree looked
 # clean. Nothing to do when the staged set has no formattable files.
+#
+# --no-errors-on-unmatched: the staged set can match the globs below yet be
+# ignored by biome.json (e.g. a commit touching only .claude/settings.json).
+# Without the flag biome exits 1 on "no files were processed" and blocks the
+# commit outright.
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.json' '*.jsonc')
 if [ -n "$STAGED" ]; then
   echo "🧹 Formatting staged files..."
-  echo "$STAGED" | tr '\n' '\0' | xargs -0 pnpm exec biome format --write
+  echo "$STAGED" | tr '\n' '\0' | xargs -0 pnpm exec biome format --write --no-errors-on-unmatched
   echo "$STAGED" | tr '\n' '\0' | xargs -0 git add
 fi
 


### PR DESCRIPTION
Two small commits. The second was blocked by a latent bug in the pre-commit hook, so the fix ships alongside it.

## `fix(husky)`: don't block commits whose staged files are all biome-ignored

`.husky/pre-commit` selects staged files by extension (`*.json` among them), then pipes them to `biome format --write`. `biome.json` ignores `**/.claude`, so a commit touching **only** `.claude/settings.json` matches the hook's glob but gets ignored by biome — which exits 1:

```
× No files were processed in the specified paths.
i These paths were provided but ignored:
  - .claude/settings.json
husky - pre-commit script failed (code 1)
```

The commit is aborted outright. This hits any commit whose entire staged set is biome-ignored, not just `.claude/`.

Fixed with `--no-errors-on-unmatched` — the flag meant for exactly this, and the one repo-tooling's own lint-staged preset already uses. Verified: the commit that was blocked now goes through, and formatting still applies to non-ignored files.

## `chore(claude)`: symlink node_modules into agent worktrees

```json
"worktree": { "symlinkDirectories": ["node_modules"] }
```

Claude Code worktrees start empty, so every agent running in one pays a full `pnpm install` before it can typecheck, lint or test.