### PR TITLE
ci(release): publish the beta branch to a beta dist-tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: 🚀 CI/CD Pipeline
 
 on:
     push:
-        branches: [main, master]
+        branches: [main, master, beta]
     pull_request:
-        branches: [main, master]
+        branches: [main, master, beta]
     # Required for GitHub merge queue. Without it, checks never run against the
     # merge group and every queued PR waits forever on contexts that cannot arrive.
     merge_group:
@@ -266,7 +266,10 @@ jobs:
         # The environment holds this job until a human approves it.
         environment: release
         needs: [dependencies, lint, typecheck, test, build, check-skip]
-        if: needs.check-skip.outputs.should-skip != 'true' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        # `beta` is a semantic-release prerelease branch: same job, but
+        # @semantic-release/npm publishes it under the `beta` dist-tag, so
+        # `npm install @rtorcato/js-common` (i.e. `latest`) never picks it up.
+        if: needs.check-skip.outputs.should-skip != 'true' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta') && github.event_name == 'push'
         steps:
             - name: 📦 Checkout repository
               uses: actions/checkout@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ The `./types` subpath is intentionally types-only — it has no `import` field, 
 - Conventional commits are **required**. Run `pnpm commit` for a guided prompt (commitizen).
 - PRs must be **squash-merged** — never rebase-merge or merge-commit.
 - `semantic-release` auto-publishes from `main` using commit messages. **Never bump the version manually** in `package.json`.
+- Pushing to a `beta` branch publishes a pre-release under the `beta` dist-tag; `latest` is untouched.
 
 ## Pre-commit Hooks
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ A comprehensive set of common JavaScript and TypeScript utilities for Node.js pr
 npm install @rtorcato/js-common
 ```
 
+Pre-release builds are published to the `beta` dist-tag, so they never reach a plain `npm install`:
+
+```bash
+npm install @rtorcato/js-common@beta
+```
+
 ## Use with AI
 
 An agent skill lives in [`skills/js-common`](./skills/js-common/SKILL.md) — it teaches an AI coding agent the subpath-import rules, which same-named helper belongs to which module, the three error idioms, which modules are Node-only, and the full module → exports map.

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -4,6 +4,10 @@ import preset from '@rtorcato/repo-tooling/semantic-release/github'
 // results, which a commit created seconds earlier can never have. Dropping
 // @semantic-release/git means no push-back to main; tag, npm publish and the
 // GitHub release are unaffected.
+// `branches` comes from the preset and already carries `{ name: 'beta',
+// prerelease: true }`, which is what makes @semantic-release/npm publish the
+// beta branch under the `beta` dist-tag instead of `latest`. Don't restate it
+// here — CI just has to run the release job on that branch too (see ci.yml).
 const plugins = preset.plugins.filter(
 	(plugin) => (Array.isArray(plugin) ? plugin[0] : plugin) !== '@semantic-release/git'
 )


### PR DESCRIPTION
## What

`release.config.mjs` already inherits `{ name: 'beta', prerelease: true }` from the `@rtorcato/repo-tooling` preset — that part of the issue was satisfied all along. The reason npm still shows `latest` only is that **CI never ran on a `beta` branch**: `ci.yml` triggers on `[main, master]` and the release job additionally gates on `github.ref == 'refs/heads/main'`, so semantic-release had no chance to publish the pre-release channel.

- `ci.yml`: trigger on `beta` (push + PR) and let the `release` job run for `refs/heads/beta`. The `environment: release` human gate is unchanged, so a beta publish still needs an approval.
- `release.config.mjs`: comment pointing at where the `beta` entry actually comes from, so this doesn't get "fixed" twice.
- `README.md`: `npm install @rtorcato/js-common@beta` documented under Installation.
- `CLAUDE.md`: one line on the pre-release channel.

## Verify

`npm view @rtorcato/js-common dist-tags` should report `beta` alongside `latest` after the first push to a `beta` branch that carries a releasable commit. Nothing can be confirmed before then — there is no `beta` branch yet.

Title is `ci(...)`, so merging this cuts no release.

Closes #173