### PR TITLE
ci(commitlint): stop capping footer lines at 72 characters

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,11 +1,19 @@
 import config from '@rtorcato/repo-tooling/commitlint/config'
 
-// config-conventional caps body lines at 72 characters. That rule is aimed at
-// `git log` in an 80-column terminal; it buys nothing here and reliably fails
-// agent-written commit bodies, leaving PRs permanently amber on a check that
-// is not required to merge. Amber checks nobody acts on are worse than none.
+// config-conventional caps body AND footer lines at 72 characters. That rule is
+// aimed at `git log` in an 80-column terminal; it buys nothing here and reliably
+// fails agent-written commit messages, leaving PRs permanently amber on a check
+// that is not required to merge. Amber checks nobody acts on are worse than none.
 // Subject-line rules stay enforced — those decide the release type.
+//
+// The footer half matters more than it looks: `BREAKING CHANGE:` is a footer, so
+// the one place a message most needs room to explain itself was the one place
+// still capped. PR #182 and #184 each burned a CI run on a 73-character line.
 export default {
 	...config,
-	rules: { ...config.rules, 'body-max-line-length': [0, 'always', Number.POSITIVE_INFINITY] },
+	rules: {
+		...config.rules,
+		'body-max-line-length': [0, 'always', Number.POSITIVE_INFINITY],
+		'footer-max-line-length': [0, 'always', Number.POSITIVE_INFINITY],
+	},
 }


### PR DESCRIPTION
`body-max-line-length` was already disabled in `commitlint.config.mjs`, with a comment explaining why: the 72-column cap is aimed at `git log` in an 80-column terminal, it buys nothing here, and it "reliably fails agent-written commit bodies, leaving PRs permanently amber on a check that is not required to merge."

That fix only covered half the rule. `footer-max-line-length` was left on — and it is the half that matters more, because **`BREAKING CHANGE:` is parsed as a footer**. The one part of a commit message that most needs room to explain itself was the one part still capped.

## Why now

Two PRs in one day failed CI on it:

- **#182** — a 73-character line. One character over. That PR has both reviewer passes and is otherwise ready.
- **#184** — its `BREAKING CHANGE:` footer, which had to be hand-rewrapped before it would commit.

Neither failure said anything about the change being wrong.

## Verification

Replaying the exact range that failed on #182 against the new config:

```
$ npx commitlint --from 57a754f --to 1cad72f
⚠   footer must have leading blank line [footer-leading-blank]
⚠   found 0 problems, 1 warnings
```

0 problems — the remaining warning is non-blocking and unrelated. #184's message passes clean.

Subject-line rules are untouched and still enforced, which is the part that decides the release type:

```
$ echo "random junk with no type" | npx commitlint   → ✖ found 2 problems
$ echo "nonsense: do a thing"     | npx commitlint   → ✖ found 1 problems
```

## Note

`commitlint` is not in the repo's required status checks (`lint`, `typecheck`, `build`, `test (22)`, `test (24)`), so this never actually blocked a merge — it just kept producing a red check that carried no signal.