### PR TITLE
chore(git): ignore node_modules symlinks in agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Node.js dependencies
-node_modules/
+# No trailing slash: agent worktrees get node_modules as a *symlink*, and a
+# trailing slash matches directories only, so `node_modules/` left the symlink
+# untracked and `git add -A` committed it.
+node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
One character, but it bites every agent worktree.

`.gitignore` line 2 was `node_modules/`. A trailing slash makes a pattern match **directories only** — and `.claude/settings.json` symlinks `node_modules` into every agent worktree, so git sees a symlink (mode `120000`), not a directory. The symlinks stayed untracked, and any `git add -A` in a worktree committed them.

Not hypothetical: this happened on the #182 branch during this session. `git add -A` staged `node_modules` and `apps/docs/node_modules` as symlink entries; it was caught on `git show --stat` before the push, but only because I looked.

## Verified both directions

In a worktree that has the symlinks, with `node_modules/`:

```
?? apps/docs/node_modules
?? node_modules
```

With the trailing slash dropped:

```
$ git check-ignore -v node_modules apps/docs/node_modules
.gitignore:2:node_modules	node_modules
.gitignore:2:node_modules	apps/docs/node_modules
```

Restoring the slash brings both back as untracked, so the pattern is doing exactly the work.

No behaviour change for a normal checkout, where `node_modules` is a real directory and both patterns match it.

`chore` rather than `fix` deliberately — nothing ships, so this should not cut a patch release.