### PR TITLE
chore(commitlint): drop the local body/footer overrides

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,19 +1,3 @@
 import config from '@rtorcato/repo-tooling/commitlint/config'
 
-// config-conventional caps body AND footer lines at 72 characters. That rule is
-// aimed at `git log` in an 80-column terminal; it buys nothing here and reliably
-// fails agent-written commit messages, leaving PRs permanently amber on a check
-// that is not required to merge. Amber checks nobody acts on are worse than none.
-// Subject-line rules stay enforced — those decide the release type.
-//
-// The footer half matters more than it looks: `BREAKING CHANGE:` is a footer, so
-// the one place a message most needs room to explain itself was the one place
-// still capped. PR #182 and #184 each burned a CI run on a 73-character line.
-export default {
-	...config,
-	rules: {
-		...config.rules,
-		'body-max-line-length': [0, 'always', Number.POSITIVE_INFINITY],
-		'footer-max-line-length': [0, 'always', Number.POSITIVE_INFINITY],
-	},
-}
+export default config

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "@biomejs/biome": "^2.5.0",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
-    "@rtorcato/repo-tooling": "^3.0.0",
+    "@rtorcato/repo-tooling": "^3.9.1",
     "@semantic-release/changelog": "^7.0.0",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^11.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^21.2.0
         version: 21.2.0
       '@rtorcato/repo-tooling':
-        specifier: ^3.0.0
-        version: 3.4.0(30d8862d0d43ceafc31e73019da20b9e)
+        specifier: ^3.9.1
+        version: 3.9.1(30d8862d0d43ceafc31e73019da20b9e)
       '@semantic-release/changelog':
         specifier: ^7.0.0
         version: 7.0.0(semantic-release@25.0.9(supports-color@8.1.1)(typescript@6.0.3))
@@ -2916,8 +2916,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rtorcato/repo-tooling@3.4.0':
-    resolution: {integrity: sha512-6qR1L4TjM1fBdLVnSrAXvWjAeZBQWs+cjiwW+k9Ym6C+KsORLul8PnzKQUmRUmjBOj9nagJ2UKdMwQxE3spe3g==}
+  '@rtorcato/repo-tooling@3.9.1':
+    resolution: {integrity: sha512-leSjjoY+s1T1E767PE7sHBfFIosbm69hXWLYaRfwBqjkc8dJKVTWc9dUU2eeAkwEUNwUctf2i5oQefkrBJjmNQ==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
@@ -12163,7 +12163,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
-  '@rtorcato/repo-tooling@3.4.0(30d8862d0d43ceafc31e73019da20b9e)':
+  '@rtorcato/repo-tooling@3.9.1(30d8862d0d43ceafc31e73019da20b9e)':
     dependencies:
       chalk: 5.6.2
       commander: 15.0.0


### PR DESCRIPTION
`@rtorcato/repo-tooling` 3.9.1 sets `body-max-line-length` and
`footer-max-line-length` to `[0]` in the shared preset, which is exactly
what this repo's `commitlint.config.mjs` was doing locally. The override
is now redundant.

## Changes

- Bump `@rtorcato/repo-tooling` 3.4.0 → 3.9.1 (lockfile).
- Reduce `commitlint.config.mjs` to a bare re-export of the preset.
- `pnpm update` also raised the devDependency floor from `^3.0.0` to
  `^3.9.1`. The issue said no `package.json` edit was needed, but this one
  is worth keeping: with the override deleted, any resolution below 3.9.1
  would silently re-enable the 72-character cap. The floor now encodes the
  requirement.

## Preset drift, 3.4.0 → 3.9.1

The bump spans five minors, so I diffed the three presets this repo
actually consumes:

- `tooling/typescript/*` — byte-identical.
- `tooling/biome/biome.json` — one change, `vcs.enabled` `false` → `true`
  (with `useIgnoreFile: true` already set). Biome now honours `.gitignore`.
- `tooling/commitlint/commitlint.mjs` — the two rules above, `[2, 'always', 72]` → `[0]`.

No other drift surfaced, so there is nothing to split out.

## Verification

Run against a real install of 3.9.1 in the worktree, not the shared
`node_modules`:

- `pnpm exec commitlint` accepts a commit whose `BREAKING CHANGE:` footer
  is well over 72 characters — the issue's stated check. Exit 0.
- `pnpm verify` (typecheck + biome check + vitest): clean, 363 tests
  passing, 150 files checked.

## Note for the reviewer

The pre-push hook initially failed in this agent worktree because
`node_modules` was a symlink into the main checkout, which made pnpm
resolve bin paths to a doubled path
(`js-common-worktrees/js-common-worktrees/...`). That is a worktree-setup
issue, unrelated to this change. Fixed by giving the worktree its own
install; the hook then ran and passed on the push above.

Closes #191