### PR TITLE
test: cover the ISO week, groupBy, detectLanguage and checkEnv gaps

### DIFF
--- a/src/arrays/index.test.ts
+++ b/src/arrays/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { chunk, compact, first, flatten, last, shuffle, unique } from './index'
+import { chunk, compact, first, flatten, groupBy, last, shuffle, unique } from './index'
 
 describe('first', () => {
 	it('returns the first element', () => {
@@ -39,6 +39,27 @@ describe('chunk', () => {
 describe('compact', () => {
 	it('removes falsy values', () => {
 		expect(compact([0, 1, false, 2, '', 3, null, undefined])).toEqual([1, 2, 3])
+	})
+})
+
+describe('groupBy', () => {
+	it('groups by a computed string key', () => {
+		expect(groupBy([1, 2, 3, 4], (n) => (n % 2 === 0 ? 'even' : 'odd'))).toEqual({
+			odd: [1, 3],
+			even: [2, 4],
+		})
+	})
+
+	it('groups objects by a property', () => {
+		const items = [{ type: 'a' }, { type: 'b' }, { type: 'a' }]
+		expect(groupBy(items, (x) => x.type)).toEqual({
+			a: [items[0], items[2]],
+			b: [items[1]],
+		})
+	})
+
+	it('returns an empty object for an empty array', () => {
+		expect(groupBy([], (n: number) => n)).toEqual({})
 	})
 })
 

--- a/src/datetime/index.test.ts
+++ b/src/datetime/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
 	formatDateTimeLocal,
+	getIsoWeek,
+	getIsoWeekInfo,
 	getTimezoneOffset,
 	nowIso,
 	parseIsoDateTime,
@@ -59,23 +61,44 @@ describe('datetime module', () => {
 		expect(typeof ms).toBe('number')
 		expect(ms).toBeGreaterThan(1000000000000)
 	})
+})
 
-	// it('getIsoWeek returns correct ISO week number', () => {
-	// 	// 2025-01-01 is week 1
-	// 	expect(getIsoWeek(new Date('2025-01-01'))).toBe(1)
-	// 	// 2025-12-31 is week 1 of next year (ISO)
-	// 	expect(getIsoWeek(new Date('2025-12-31'))).toBe(1)
-	// 	// 2025-05-26 is week 22
-	// 	expect(getIsoWeek(new Date('2025-05-26'))).toBe(22)
-	// })
-	// it('getIsoWeek returns correct ISO week number', () => {
-	// 	expect(getIsoWeek(new Date(Date.UTC(2025, 0, 1)))).toBe(1)
-	// 	expect(getIsoWeek(new Date(Date.UTC(2025, 11, 31)))).toBe(1) // 2025-12-31
-	// 	expect(getIsoWeek(new Date(Date.UTC(2025, 4, 26)))).toBe(22) // 2025-05-26
-	// })
-	// it('getIsoWeek returns correct ISO week number', () => {
-	// 	expect(getIsoWeekInfo(new Date(Date.UTC(2025, 0, 1)))).toEqual({ week: 1, year: 2025 })
-	// 	expect(getIsoWeekInfo(new Date(Date.UTC(2025, 11, 31)))).toEqual({ week: 1, year: 2026 })
-	// 	expect(getIsoWeekInfo(new Date(Date.UTC(2025, 4, 26)))).toEqual({ week: 22, year: 2025 }) // ✅ fixed
-	// })
+// `getIsoWeek` and `getIsoWeekInfo` read the *local* calendar fields of their input
+// (getFullYear/getMonth/getDate) before re-projecting onto UTC. Feeding them a
+// UTC-constructed date (`new Date('2025-01-01')` or `new Date(Date.UTC(...))`) therefore
+// shifts the day by one in any zone behind UTC — which is why the earlier attempts at
+// these tests were commented out rather than fixed. Constructing with local components
+// makes them timezone-independent.
+describe('getIsoWeek', () => {
+	it('returns the ISO week number', () => {
+		expect(getIsoWeek(new Date(2025, 0, 1))).toBe(1) // Wed 2025-01-01
+		expect(getIsoWeek(new Date(2025, 4, 26))).toBe(22) // Mon 2025-05-26
+		expect(getIsoWeek(new Date(2025, 11, 31))).toBe(1) // rolls into ISO week 1 of 2026
+	})
+
+	it('counts week 53 in a long ISO year', () => {
+		expect(getIsoWeek(new Date(2020, 11, 31))).toBe(53)
+	})
+})
+
+describe('getIsoWeekInfo', () => {
+	it('returns the ISO week and the ISO week year', () => {
+		expect(getIsoWeekInfo(new Date(2025, 0, 1))).toEqual({ week: 1, year: 2025 })
+		expect(getIsoWeekInfo(new Date(2025, 4, 26))).toEqual({ week: 22, year: 2025 })
+	})
+
+	it('reports the next ISO year for a late-December date', () => {
+		expect(getIsoWeekInfo(new Date(2025, 11, 31))).toEqual({ week: 1, year: 2026 })
+	})
+
+	it('reports the previous ISO year for an early-January date', () => {
+		// Fri 2021-01-01 belongs to ISO week 53 of 2020.
+		expect(getIsoWeekInfo(new Date(2021, 0, 1))).toEqual({ week: 53, year: 2020 })
+	})
+
+	it('agrees with getIsoWeek on the week number', () => {
+		for (const d of [new Date(2025, 0, 1), new Date(2025, 4, 26), new Date(2025, 11, 31)]) {
+			expect(getIsoWeekInfo(d).week).toBe(getIsoWeek(d))
+		}
+	})
 })

--- a/src/env/index.test.ts
+++ b/src/env/index.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
-import { getENV, getNodeEnv, isDev, isProd, isTest } from './index'
+import { z } from 'zod'
+import { checkEnv, getENV, getNodeEnv, isDev, isProd, isTest, RootApiEnvSchema } from './index'
 
 describe('env module', () => {
 	const OLD_ENV = process.env
@@ -53,5 +54,55 @@ describe('env module', () => {
 		expect(getNodeEnv()).toBe('production')
 		process.env.NODE_ENV = undefined
 		expect(getNodeEnv()).toBe('development')
+	})
+})
+
+describe('checkEnv', () => {
+	const schema = z.object({
+		API_URL: z.string(),
+		PORT: z.coerce.number(),
+	})
+
+	it('returns the parsed environment when it is valid', () => {
+		expect(checkEnv(schema, { API_URL: 'https://example.com', PORT: '8080' })).toEqual({
+			API_URL: 'https://example.com',
+			PORT: 8080,
+		})
+	})
+
+	it('throws listing the missing keys when validation fails', () => {
+		expect(() => checkEnv(schema, { PORT: '8080' })).toThrow(
+			'Missing required values in .env:\nAPI_URL'
+		)
+	})
+
+	it('strips the stack so the message is the whole error', () => {
+		let caught: Error | undefined
+		try {
+			checkEnv(schema, {})
+		} catch (error) {
+			caught = error as Error
+		}
+		expect(caught?.stack).toBe('')
+		expect(caught?.message).toContain('API_URL')
+		expect(caught?.message).toContain('PORT')
+	})
+
+	it('rethrows non-Zod errors untouched', () => {
+		const boom = new Error('boom')
+		const exploding = {
+			parse: () => {
+				throw boom
+			},
+		} as unknown as typeof schema
+		expect(() => checkEnv(exploding, {})).toThrow(boom)
+	})
+
+	it('applies RootApiEnvSchema defaults to an empty environment', () => {
+		expect(checkEnv(RootApiEnvSchema, {})).toEqual({
+			NODE_ENV: 'development',
+			LOG_LEVEL: 'info',
+			PORT: 3000,
+		})
 	})
 })

--- a/src/i18n/i18n.test.ts
+++ b/src/i18n/i18n.test.ts
@@ -1,19 +1,36 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { detectLanguage, formatDateI18n, formatNumber, t } from '.'
 
 describe('detectLanguage', () => {
-	it('returns the default language when no environment signals are present', () => {
-		const lang = detectLanguage('en')
-		expect(typeof lang).toBe('string')
-		expect(lang.length).toBeGreaterThan(0)
+	const originalLang = process.env['LANG']
+
+	afterEach(() => {
+		vi.unstubAllGlobals()
+		if (originalLang === undefined) delete process.env['LANG']
+		else process.env['LANG'] = originalLang
 	})
+
+	it('prefers navigator.language and strips the region subtag', () => {
+		vi.stubGlobal('navigator', { language: 'en-GB' })
+		expect(detectLanguage('fr')).toBe('en')
+	})
+
+	it('falls back to the LANG environment variable outside the browser', () => {
+		vi.stubGlobal('navigator', undefined)
+		process.env['LANG'] = 'fr_FR.UTF-8'
+		expect(detectLanguage('en')).toBe('fr')
+	})
+
 	it('uses the provided default when nothing is detectable', () => {
-		const orig = process.env['LANG']
+		vi.stubGlobal('navigator', undefined)
 		delete process.env['LANG']
-		const lang = detectLanguage('fr')
-		// In a Node test environment without LANG set and no navigator, returns default
-		expect(['fr', 'en']).toContain(lang) // allow 'en' if CI sets it
-		process.env['LANG'] = orig
+		expect(detectLanguage('fr')).toBe('fr')
+	})
+
+	it('defaults to "en" when no default is given', () => {
+		vi.stubGlobal('navigator', undefined)
+		delete process.env['LANG']
+		expect(detectLanguage()).toBe('en')
 	})
 })
 


### PR DESCRIPTION
The Test Coverage workflow has been red on every PR: lines and statements sat
under the 85% global threshold and #184 pushed functions under 95% too.

Raises real coverage rather than moving the thresholds:

- datetime: `getIsoWeek` / `getIsoWeekInfo` had tests, but three successive
  attempts were left commented out. Both functions read the *local* calendar
  fields of their input before re-projecting onto UTC, so the UTC-constructed
  dates every attempt used (`new Date('2025-01-01')`, `new Date(Date.UTC(...))`)
  shift a day in any zone behind UTC. Rewritten with local components, which
  makes them timezone-independent, plus the week-53 and ISO-year-boundary cases.
- arrays: `groupBy` was entirely untested.
- i18n: `detectLanguage` only had a test that accepted either answer. Now stubs
  `navigator` to pin the browser branch, the LANG branch, and both defaults.
- env: `checkEnv` was entirely untested, including the ZodError message and the
  non-Zod rethrow.

Totals go from 83.13% lines / 83.23% statements / 95.51% functions to
88.12% / 87.88% / 97.11%. No threshold was touched and no file was excluded.

Closes #189
