### PR TITLE
chore(worktree): symlink apps/docs/node_modules into agent worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,6 @@
     ]
   },
   "worktree": {
-    "symlinkDirectories": ["node_modules"]
+    "symlinkDirectories": ["node_modules", "apps/docs/node_modules"]
   }
 }


### PR DESCRIPTION
Adds `apps/docs/node_modules` to `worktree.symlinkDirectories`, so an agent worktree can run the docs build — the only check that catches broken documentation links.

Closes #193

## The verification the issue asked for

The issue held this back as an issue rather than a one-line PR because nested paths in `symlinkDirectories` were unconfirmed. They work:

- Claude Code rejects only absolute paths and `..` segments. Every entry is joined onto both the repo root and the worktree root, so a nested relative path resolves correctly. Every failure branch warns and continues, so a bad entry cannot break worktree creation for other agents.
- Symlinking runs after `git worktree add` has checked out the tree, so the `apps/docs` parent directory already exists when the link is made.

Checked against a freshly created worktree, not just read from the source:

- both `node_modules` and `apps/docs/node_modules` are symlinked;
- `git check-ignore -v` traces both to `.gitignore:5`, so `git add -A` in a worktree stays clean (#192);
- `pnpm --filter @rtorcato/js-common-docs build` runs to completion (exit 0, `Generated static files in "build"`), where it previously died with `docusaurus: command not found`.

## One thing that came up, and why it is not this PR

Midway through, every pnpm binary broke in *all four* agent worktrees — `tsc` resolved to a nonexistent doubled path (`js-common-worktrees/js-common-worktrees/ai-191-.../node_modules/.pnpm/...`), surfacing as a confusing `MODULE_NOT_FOUND` in the pre-commit hook.

That is not caused by symlinking, and not by this change. The root `node_modules` symlink has been in place all along. The cause is running `pnpm install` **inside** a worktree whose `node_modules` is a symlink: pnpm writes through the link and re-points the *shared* root `.bin` shims at that worktree's virtual store. The main repo kept working only because the bad path happened to resolve back through another worktree's symlink — so the shared install had become dependent on a worktree that could be deleted at any time.

`pnpm install --frozen-lockfile` from the main repo restored it (node_modules only; no lockfile or tracked-file change), and typecheck/lint pass in the worktree again — this commit went through the pre-commit hook normally.

Worth noting that this PR reduces the pressure that causes that breakage: the missing docs binary is exactly what tempts an agent to run `pnpm install` inside a worktree. Making the binary resolve without an install is the point. A guardrail against in-worktree `pnpm install` is a separate concern and probably deserves its own issue.