### PR TITLE
fix: make the ReDoS-flagged regexes linear-time

### DIFF
--- a/src/currency/index.test.ts
+++ b/src/currency/index.test.ts
@@ -84,6 +84,7 @@ describe('currency module', () => {
 
 		it('parses European format price strings', () => {
 			expect(parsePrice('€1.234,56')).toBeCloseTo(1234.56)
+			expect(parsePrice('€1.234.567,89')).toBeCloseTo(1234567.89)
 		})
 
 		it('returns null for invalid strings', () => {

--- a/src/currency/index.ts
+++ b/src/currency/index.ts
@@ -182,7 +182,9 @@ export function formatPriceCompact(
  */
 export function parsePrice(value: string): number | null {
 	// Handle European format (1.234,56) by detecting comma as decimal separator
-	const hasEuropeanFormat = /\d+\.\d{3},\d{2}$/.test(value)
+	// One leading \d, not \d+ — the test is the same (both need a digit before the dot), but
+	// with no unbounded quantifier it stays linear on '999…9' (CodeQL js/polynomial-redos).
+	const hasEuropeanFormat = /\d\.\d{3},\d{2}$/.test(value)
 	let normalized = value
 
 	if (hasEuropeanFormat) {

--- a/src/emails/index.test.ts
+++ b/src/emails/index.test.ts
@@ -16,6 +16,12 @@ describe('emails module', () => {
 		expect(isValidEmail('foo@.com')).toBe(false)
 	})
 
+	it('isValidEmail rejects empty and trailing domain labels', () => {
+		expect(isValidEmail('foo@bar..com')).toBe(false)
+		expect(isValidEmail('foo@bar.com.')).toBe(false)
+		expect(isValidEmail('foo.bar@baz.example.com')).toBe(true)
+	})
+
 	it('normalizeEmail trims and lowercases', () => {
 		expect(normalizeEmail('  TEST@Example.COM  ')).toBe('test@example.com')
 	})

--- a/src/emails/index.ts
+++ b/src/emails/index.ts
@@ -12,7 +12,9 @@
  * @returns True if valid, false otherwise.
  */
 export function isValidEmail(email: string): boolean {
-	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+	// The domain parts exclude '.' so each one has a single possible split, which keeps the
+	// match linear on inputs like 'a@!.!.!.!.' (CodeQL js/polynomial-redos).
+	return /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/.test(email)
 }
 
 /**

--- a/src/html/index.test.ts
+++ b/src/html/index.test.ts
@@ -21,6 +21,20 @@ describe('html module', () => {
 		expect(stripHtmlTags('no tags')).toBe('no tags')
 	})
 
+	it('stripHtmlTags matches what /<[^>]*>/g did on ragged input', () => {
+		const cases = ['<<a>script>', '<scr<x>ipt>', 'a<b', '<<<', '<>', 'a>b<c>d', '']
+		for (const input of cases) {
+			expect(stripHtmlTags(input)).toBe(input.replace(/<[^>]*>/g, ''))
+		}
+	})
+
+	it('stripHtmlTags leaves nothing a second pass would strip', () => {
+		for (const input of ['<<a>script>', '<scr<x>ipt>', '<a<b>c>']) {
+			const once = stripHtmlTags(input)
+			expect(stripHtmlTags(once)).toBe(once)
+		}
+	})
+
 	it('textToHtml converts newlines to <br>', () => {
 		expect(textToHtml('a\nb\nc')).toBe('a<br>b<br>c')
 		expect(textToHtml('no newlines')).toBe('no newlines')
@@ -30,5 +44,12 @@ describe('html module', () => {
 		expect(containsHtml('<div>')).toBe(true)
 		expect(containsHtml('plain')).toBe(false)
 		expect(containsHtml('a <b>bold</b> word')).toBe(true)
+	})
+
+	it('containsHtml matches what /<[^>]+>/ did on ragged input', () => {
+		const cases = ['<>', '<><a>', '<<>', '<a<b>', 'a<b', '<<<', '']
+		for (const input of cases) {
+			expect(containsHtml(input)).toBe(/<[^>]+>/.test(input))
+		}
 	})
 })

--- a/src/html/index.test.ts
+++ b/src/html/index.test.ts
@@ -21,10 +21,25 @@ describe('html module', () => {
 		expect(stripHtmlTags('no tags')).toBe('no tags')
 	})
 
-	it('stripHtmlTags matches what /<[^>]*>/g did on ragged input', () => {
-		const cases = ['<<a>script>', '<scr<x>ipt>', 'a<b', '<<<', '<>', 'a>b<c>d', '']
-		for (const input of cases) {
-			expect(stripHtmlTags(input)).toBe(input.replace(/<[^>]*>/g, ''))
+	// Expectations are hardcoded, not computed from the retired regex: the old
+	// construct is exactly what this rewrite is removing from the codebase.
+	// Each pair below was checked against the old behaviour by hand.
+	it('stripHtmlTags matches the old regex output on ragged input', () => {
+		const cases: [input: string, expected: string][] = [
+			['<<a>script>', 'script>'],
+			['<scr<x>ipt>', 'ipt>'],
+			['<scr<script>ipt>', 'ipt>'],
+			['<<script>script>', 'script>'],
+			['<scr<x>ipt>alert(1)', 'ipt>alert(1)'],
+			['<img/onerror=x>', ''],
+			['a<b', 'a<b'],
+			['<<<', '<<<'],
+			['<>', ''],
+			['a>b<c>d', 'a>bd'],
+			['', ''],
+		]
+		for (const [input, expected] of cases) {
+			expect(stripHtmlTags(input)).toBe(expected)
 		}
 	})
 

--- a/src/html/index.ts
+++ b/src/html/index.ts
@@ -73,7 +73,17 @@ function findTag(str: string, from: number): { open: number; close: number } | n
  * ```typescript
  * stripHtmlTags('<p>Hello <b>world</b></p>') // 'Hello world'
  * stripHtmlTags('plain text') // 'plain text'
+ *
+ * // Strips `<…>` spans, so ragged input leaves residue — not a sanitizer.
+ * stripHtmlTags('<<a>script>') // 'script>'
+ * stripHtmlTags('<scr<x>ipt>') // 'ipt>'
  * ```
+ *
+ * Removes `<…>` spans and nothing else: it does not decode entities and does
+ * not understand attributes or quoting, so ragged or nested markup leaves
+ * attacker-controlled residue behind rather than a safe string. Not a
+ * substitute for a real sanitizer such as DOMPurify when rendering untrusted
+ * HTML — this produces display text, it does not make untrusted markup safe.
  *
  * @param str The string to strip tags from.
  * @returns The plain text string.
@@ -99,6 +109,11 @@ export function textToHtml(str: string): string {
 
 /**
  * Checks if a string contains any HTML tags.
+ *
+ * A heuristic for "does this look like markup", not a security gate: it only
+ * looks for a non-empty `<…>` span, so `'a<b'` and `'<>'` are both false. Do
+ * not use it to decide whether untrusted input is safe to render.
+ *
  * @param str The string to check.
  * @returns True if the string contains HTML tags, false otherwise.
  */

--- a/src/html/index.ts
+++ b/src/html/index.ts
@@ -51,6 +51,22 @@ export function unescapeHtml(str: string): string {
 }
 
 /**
+ * Finds the next `<…>` span at or after `from`, matching what `/<[^>]*>/` would match.
+ *
+ * ponytail: an index scan rather than the regex — same spans, but linear in the length of
+ * the input instead of quadratic on inputs like `'<<<<<<<'` (CodeQL `js/polynomial-redos`).
+ *
+ * A `<` with no `>` after it is not a span, and neither is anything later in the string,
+ * so `null` ends the search.
+ */
+function findTag(str: string, from: number): { open: number; close: number } | null {
+	const open = str.indexOf('<', from)
+	if (open === -1) return null
+	const close = str.indexOf('>', open + 1)
+	return close === -1 ? null : { open, close }
+}
+
+/**
  * Strips all HTML tags from a string.
  *
  * @example
@@ -63,7 +79,13 @@ export function unescapeHtml(str: string): string {
  * @returns The plain text string.
  */
 export function stripHtmlTags(str: string): string {
-	return str.replace(/<[^>]*>/g, '')
+	let out = ''
+	let i = 0
+	for (let tag = findTag(str, i); tag; tag = findTag(str, i)) {
+		out += str.slice(i, tag.open)
+		i = tag.close + 1
+	}
+	return out + str.slice(i)
 }
 
 /**
@@ -81,5 +103,9 @@ export function textToHtml(str: string): string {
  * @returns True if the string contains HTML tags, false otherwise.
  */
 export function containsHtml(str: string): boolean {
-	return /<[^>]+>/.test(str)
+	// Same matches as /<[^>]+>/ — the `close > open + 1` check is the `+` (an empty `<>` is not a tag).
+	for (let tag = findTag(str, 0); tag; tag = findTag(str, tag.close + 1)) {
+		if (tag.close > tag.open + 1) return true
+	}
+	return false
 }

--- a/src/url/index.test.ts
+++ b/src/url/index.test.ts
@@ -54,6 +54,12 @@ describe('joinUrl', () => {
 		expect(joinUrl('/a/', '/b/', '/c/')).toBe('/a/b/c')
 		expect(joinUrl('a', 'b', 'c')).toBe('a/b/c')
 	})
+
+	it('collapses runs of slashes and drops all-slash segments', () => {
+		expect(joinUrl('https://a.com///', '///foo///', '//bar//')).toBe('https://a.com/foo/bar')
+		expect(joinUrl('a', '///', 'b')).toBe('a/b')
+		expect(joinUrl('///')).toBe('')
+	})
 })
 
 describe('getHostname', () => {

--- a/src/url/index.ts
+++ b/src/url/index.ts
@@ -87,16 +87,27 @@ export function removeQueryParam(url: string, key: string): string {
 }
 
 /**
+ * Trims slashes off a URL segment — always trailing, and leading too when `leading` is set.
+ *
+ * ponytail: an index scan rather than `/^\/+|\/+$/g` — same result, but linear on inputs
+ * like `'//////'` instead of quadratic (CodeQL `js/polynomial-redos`).
+ */
+function trimSlashes(part: string, leading: boolean): string {
+	let start = 0
+	let end = part.length
+	if (leading) while (start < end && part[start] === '/') start++
+	while (end > start && part[end - 1] === '/') end--
+	return part.slice(start, end)
+}
+
+/**
  * Joins multiple URL segments into a single URL, ensuring proper slashes.
  * @param parts The URL segments.
  * @returns The joined URL string.
  */
 export function joinUrl(...parts: string[]): string {
 	return parts
-		.map((part, i) => {
-			if (i === 0) return part.replace(/\/+$/, '')
-			return part.replace(/^\/+|\/+$/g, '')
-		})
+		.map((part, i) => trimSlashes(part, i > 0))
 		.filter(Boolean)
 		.join('/')
 }

--- a/src/validation/index.test.ts
+++ b/src/validation/index.test.ts
@@ -56,6 +56,8 @@ describe('validation utils', () => {
 		expect(isEmail('not-an-email')).toBe(false)
 		expect(isEmail('foo@bar')).toBe(false)
 		expect(isEmail('foo@.com')).toBe(false)
+		expect(isEmail('foo@bar..com')).toBe(false)
+		expect(isEmail('foo@bar.com.')).toBe(false)
 	})
 
 	it('isUrl', () => {

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -88,7 +88,9 @@ export function isObject(value: unknown): value is object {
  * @returns {boolean}
  */
 export function isEmail(str: string): boolean {
-	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(str)
+	// Same regex as emails.isValidEmail: domain parts exclude '.' so the match stays linear
+	// on inputs like 'a@!.!.!.!.' (CodeQL js/polynomial-redos).
+	return /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/.test(str)
 }
 
 /**


### PR DESCRIPTION
Closes #190

Fixes the mechanical ReDoS alerts, documents the one weakness that cannot be
fixed by rewriting a scan, and leaves the alerts that need an owner decision.

## Fixed: ReDoS (quadratic → linear)

All of these were ambiguous unbounded quantifiers — a long crafted string costs
quadratic time.

| Alert | Location | Fix |
|---|---|---|
| #8, #15 `js/polynomial-redos` | `emails.isValidEmail`, `validation.isEmail` | domain labels now exclude `.`, so each split is unique |
| #13, #14 `js/polynomial-redos` | `url.joinUrl` | index scan instead of `/^\/+\|\/+$/g` |
| #16 `js/polynomial-redos` | `currency.parsePrice` | `\d` instead of `\d+` — identical test, no unbounded quantifier |
| #26 `js/polynomial-redos` | `html.stripHtmlTags` | one `indexOf` scan for `<` then `>` |
| #10 `js/polynomial-redos` | `html.containsHtml` | same scan |

**The email regexes get stricter.** `foo@bar..com` and `foo@bar.com.` were
accepted before and are rejected now (the old `[^\s@]+` swallowed dots). That is
the behaviour change that makes this a `fix:` rather than a `chore:`. Both cases
are pinned by new tests.

## Not fixed, now documented: `stripHtmlTags` incomplete sanitization (#27)

**Correcting an earlier version of this PR description, which claimed this alert
was fixed. It was not.**

The `indexOf` rewrite is behaviour-preserving — it matches the old
`/<[^>]*>/g` span for span, byte for byte, including on ragged input:

| input | old | new |
|---|---|---|
| `<scr<script>ipt>` | `ipt>` | `ipt>` |
| `<<script>script>` | `script>` | `script>` |
| `<<a>script>` | `script>` | `script>` |

So the weakness the alert describes is exactly as present as it was before. What
changed is only the *detection*: CodeQL pattern-matches the regex shape, and an
index scan is not a shape it recognises as a sanitizer, so it stopped reporting.
The new alert this PR briefly introduced on its own test file was the proof —
the same rule fired on the test's oracle, the last place the old construct
survived.

A tag stripper cannot be made safe by rewriting the scan. The honest fix for
this alert class is to say so, which is what this PR now does:
`stripHtmlTags`'s JSDoc carries a "not a sanitizer" caveat matching the one
already on `security.sanitizeString`, and `containsHtml` gets a matching note
that it is a heuristic, not a security gate.

The test that pins the old/new equivalence now hardcodes its expected outputs
instead of computing them with `/<[^>]*>/g` — the equivalence claim is worth
testing, but not with the construct being retired.

## Deliberately left (4 alerts, all on `security.sanitizeString`)

#1 `js/bad-tag-filter`, #4 and #5 `js/incomplete-multi-character-sanitization`,
and #11 `js/polynomial-redos`, all on `src/security/index.ts:19`. The issue is
explicit that keep-and-rename vs drop-for-DOMPurify vs dismiss-with-rationale is
the owner's call, not an agent's, so `sanitizeString` is untouched.

**Merger, note:** `Closes #190` will close that issue on merge, so those four
alerts need a follow-up issue or they become invisible.

(The issue's count of 15 included three alerts in
`scripts/generate-module-docs.mjs` that are already closed; 12 were open when
this PR opened.)

## Verification

`pnpm typecheck`, `pnpm check`, `pnpm test` (368 passed, 3 skipped) all clean.
`pnpm docs:generate` produces no diff.
