### PR TITLE
docs: replace phantom export names with the real ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See [CLI.md](./CLI.md) for complete CLI documentation.
 // Import specific modules (recommended for tree-shaking)
 import { formatDate, today, daysBetween } from '@rtorcato/js-common/date'
 import { isValidEmail, normalizeEmail } from '@rtorcato/js-common/emails'
-import { generateUUID, isValidUUID } from '@rtorcato/js-common/uuid'
+import { getUUID, isUUID } from '@rtorcato/js-common/uuid'
 import { sum, average, roundTo } from '@rtorcato/js-common/numbers'
 import { capitalize, titleCase } from '@rtorcato/js-common/strings'
 
@@ -122,7 +122,7 @@ import { capitalize, titleCase } from '@rtorcato/js-common/strings'
 console.log(today()) // "2026-05-29"
 console.log(sum([1, 2, 3, 4, 5])) // 15
 console.log(capitalize('hello world')) // "Hello world"
-console.log(generateUUID()) // "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+console.log(getUUID()) // "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 ```
 
 ### Bundle Size Impact

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -45,14 +45,14 @@ Import named functions from a subpath export to keep your bundle tiny:
 import { today, daysBetween } from '@rtorcato/js-common/date'
 import { sum, average } from '@rtorcato/js-common/numbers'
 import { capitalize } from '@rtorcato/js-common/strings'
-import { generateUUID } from '@rtorcato/js-common/uuid'
+import { getUUID } from '@rtorcato/js-common/uuid'
 
 today()                                  // "2026-06-12"
 daysBetween('2026-01-01', '2026-06-12')  // 162
 sum([1, 2, 3, 4, 5])                     // 15
 average([10, 20, 30])                    // 20
 capitalize('hello world')                // "Hello world"
-generateUUID()                           // "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+getUUID()                                // "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 ```
 
 Always import from a subpath — never from the package root:
@@ -80,11 +80,11 @@ See [Tree-shaking & imports](./guides/tree-shaking.md) for the full explanation.
 | Area | Subpath | Example helpers |
 | --- | --- | --- |
 | Dates & time | `date`, `datetime`, `time` | `today`, `daysBetween`, `formatRelative`, `nowIso`, `unixTimestamp` |
-| Numbers & math | `numbers`, `math`, `currency` | `sum`, `average`, `roundTo`, `clamp`, `formatCurrency` |
-| Strings | `strings`, `html`, `regex` | `slugify`, `truncate`, `capitalize`, `removeEmojis` |
+| Numbers & math | `numbers`, `geometry`, `currency` | `sum`, `average`, `roundTo`, `clamp`, `formatPrice` |
+| Strings | `strings`, `html`, `regex` | `slugify`, `truncate`, `capitalize`, `escapeHtml` |
 | Collections | `arrays`, `objects`, `sets`, `maps` | `unique`, `chunk`, `groupBy`, `deepMerge`, `pick`, `omit` |
-| Async | `promises`, `sleep`, `abortController`, `functions` | `retry`, `timeout`, `delay`, `debounce`, `throttle` |
-| Validation | `validation`, `emails`, `url`, `uuid` | `isValidEmail`, `isValidUrl`, `generateUUID` |
+| Async | `promises`, `sleep`, `abortController`, `functions` | `delay`, `withTimeout`, `sleep`, `debounce`, `throttle` |
+| Validation | `validation`, `emails`, `url`, `uuid` | `isValidEmail`, `isValidUrl`, `getUUID` |
 | System | `env`, `os`, `node`, `process`, `system` | environment, platform, runtime info |
 | Other | `json`, `fetch`, `file`, `logger`, `security`, `i18n`, `html` | `safeJsonParse`, `isStrongPassword`, … |
 

--- a/apps/docs/docs/modules/overview.md
+++ b/apps/docs/docs/modules/overview.md
@@ -13,16 +13,16 @@ Every module is exported under its own subpath so bundlers can tree-shake unused
 | Time | `@rtorcato/js-common/time` | `nowTime`, `parseTime`, `secondsBetween` |
 | Numbers | `@rtorcato/js-common/numbers` | `sum`, `average`, `roundTo`, `clamp`, `formatPercent` |
 | Random | `@rtorcato/js-common/random` | `randomInt`, `randomFloat`, `randomBool`, `randomString` |
-| Strings | `@rtorcato/js-common/strings` | `slugify`, `truncate`, `removeEmojis`, `capitalize` |
+| Strings | `@rtorcato/js-common/strings` | `slugify`, `truncate`, `titleCase`, `capitalize` |
 | Arrays | `@rtorcato/js-common/arrays` | `flatten`, `unique`, `chunk`, `groupBy` |
 | Objects | `@rtorcato/js-common/objects` | `deepMerge`, `pick`, `omit`, `deepClone` |
 | JSON | `@rtorcato/js-common/json` | `safeJsonParse`, `safeJsonStringify` |
-| Emails | `@rtorcato/js-common/emails` | `validateEmail`, `isValidEmail` |
+| Emails | `@rtorcato/js-common/emails` | `isValidEmail`, `normalizeEmail`, `maskEmail` |
 | URL | `@rtorcato/js-common/url` | `isValidUrl` |
-| UUID | `@rtorcato/js-common/uuid` | `generateUUID`, `isValidUUID` |
+| UUID | `@rtorcato/js-common/uuid` | `getUUID`, `getUUIDv7`, `isUUID` |
 | Security | `@rtorcato/js-common/security` | `isStrongPassword`, `generateSecureToken` |
 | Validation | `@rtorcato/js-common/validation` | `isString`, `isNumber`, `isArray`, `isObject` |
-| Promises | `@rtorcato/js-common/promises` | `delay`, `timeout`, `retry` |
+| Promises | `@rtorcato/js-common/promises` | `delay`, `withTimeout`, `to` |
 | Functions | `@rtorcato/js-common/functions` | `debounce`, `throttle`, `once` |
 | Sleep | `@rtorcato/js-common/sleep` | `sleep` |
 

--- a/apps/docs/docs/modules/strings.md
+++ b/apps/docs/docs/modules/strings.md
@@ -7,12 +7,12 @@ sidebar_position: 4
 Everyday string shaping — slugs, truncation, casing, padding, pluralisation. Every function returns a new string and leaves its input alone; `truncate` counts its ellipsis inside the requested length rather than adding to it. `slugify` strips diacritics and then keeps only `a-z0-9` and hyphens, which makes it URL-safe by construction but also means non-Latin scripts slug to an empty string — transliterate first if you need to support them.
 
 ```ts
-import { slugify, truncate, capitalize, removeEmojis } from '@rtorcato/js-common/strings'
+import { slugify, truncate, capitalize, pluralize } from '@rtorcato/js-common/strings'
 
 slugify('Hello World!')             // "hello-world"
 truncate('Lorem ipsum dolor', 10)   // "Lorem ips…"
 capitalize('hello world')           // "Hello world"
-removeEmojis('hi 👋 there 🎉')      // "hi  there "
+pluralize('item', 5)                // "items"
 ```
 
 ## See also

--- a/apps/docs/docs/modules/uuid.md
+++ b/apps/docs/docs/modules/uuid.md
@@ -7,13 +7,13 @@ sidebar_position: 5
 UUID generation, validation and conversion, wrapping the `uuid` and `short-uuid` packages rather than hand-rolling either. Generation draws from a CSPRNG and validation is version-aware, so a plausible-looking but malformed id is rejected instead of slipping through a loose regex. v4 is the default when you want no embedded information; v7 is there when you want time-ordered ids that index well as database primary keys, and the short forms are the same value in a shorter alphabet, not a different id.
 
 ```ts
-import { generateUUID, isValidUUID } from '@rtorcato/js-common/uuid'
+import { getUUID, isUUID } from '@rtorcato/js-common/uuid'
 
-const id = generateUUID()
+const id = getUUID()
 // "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 
-isValidUUID(id)        // true
-isValidUUID('not-a-id') // false
+isUUID(id)         // true
+isUUID('not-a-id') // false
 ```
 
 ## See also


### PR DESCRIPTION
The quick start, README usage block and several module pages imported
names the package has never exported, so the first sample a new user
copy-pastes fails to build.

Verified every replacement against src/<module>/index.ts:

- uuid.generateUUID -> getUUID, uuid.isValidUUID -> isUUID
- emails.validateEmail -> isValidEmail (plus normalizeEmail, maskEmail)
- promises.timeout -> withTimeout; promises.retry does not exist -> to
- strings.removeEmojis does not exist -> pluralize / titleCase / escapeHtml
- numbers.formatCurrency -> currency.formatPrice
- the `math` subpath does not exist -> geometry

No helpers were added: the missing removeEmojis and retry are a separate
API call, and the module paths are frozen as of #174.

Closes #185
