### PR TITLE
fix(cli): print importable export names from `add`

### DIFF
--- a/src/cli/catalog.test.ts
+++ b/src/cli/catalog.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { functionCategories } from './catalog.js'
+
+const entries = Object.entries(functionCategories).flatMap(([category, { functions }]) =>
+	functions.map((func) => ({ category, ...func }))
+)
+
+describe('cli function catalog', () => {
+	it.each(entries)(
+		'js-common $category $name → $exportName from ./$subpath',
+		async ({ exportName, subpath }) => {
+			const mod = await import(`../${subpath}/index.ts`)
+
+			expect(Object.keys(mod)).toContain(exportName)
+		}
+	)
+})

--- a/src/cli/catalog.ts
+++ b/src/cli/catalog.ts
@@ -1,0 +1,194 @@
+// Catalog of the functions the CLI advertises, used by `list`, `interactive`
+// and `add`.
+//
+// Three names per entry, and they are deliberately different things:
+//   - `name`       the CLI verb (`js-common math avg`) — part of the CLI surface
+//   - `exportName` the real library export (`average`) — what `add` must print
+//   - `subpath`    the published module the export lives in (`numbers`)
+//
+// `subpath` is per entry, not per category: the CLI groups by task ('math',
+// 'system') while the library groups by module — 'math' spans `numbers` and
+// `random`, 'system' spans `process` and `node`.
+//
+// `src/cli/catalog.test.ts` asserts every `exportName` really is exported by
+// `src/<subpath>/index.ts`, so this cannot drift back into fiction.
+export const functionCategories = {
+	date: {
+		name: '📅 Date & Time',
+		functions: [
+			{
+				name: 'today',
+				description: "Get today's date (YYYY-MM-DD)",
+				exportName: 'today',
+				subpath: 'date',
+				example: `const date = today() // '${new Date().toISOString().slice(0, 10)}'`,
+			},
+			{
+				name: 'now',
+				description: 'Get current timestamp',
+				exportName: 'nowIso',
+				subpath: 'datetime',
+				example: `const timestamp = nowIso() // '${new Date().toISOString()}'`,
+			},
+			{
+				name: 'between',
+				description: 'Calculate days between dates',
+				exportName: 'daysBetween',
+				subpath: 'date',
+				example: `const days = daysBetween('2023-01-01', '2023-12-31') // 364`,
+			},
+		],
+	},
+	math: {
+		name: '🔢 Mathematical',
+		functions: [
+			{
+				name: 'sum',
+				description: 'Calculate sum of numbers',
+				exportName: 'sum',
+				subpath: 'numbers',
+				example: `const total = sum([1, 2, 3, 4, 5]) // 15`,
+			},
+			{
+				name: 'avg',
+				description: 'Calculate average of numbers',
+				exportName: 'average',
+				subpath: 'numbers',
+				example: `const mean = average([10, 20, 30]) // 20`,
+			},
+			{
+				name: 'random',
+				description: 'Generate random number',
+				exportName: 'randomInt',
+				subpath: 'random',
+				example: `const num = randomInt(1, 100) // 42`,
+			},
+			{
+				name: 'round',
+				description: 'Round to decimal places',
+				exportName: 'roundTo',
+				subpath: 'numbers',
+				example: `const rounded = roundTo(3.14159, 2) // 3.14`,
+			},
+			{
+				name: 'clamp',
+				description: 'Clamp between min/max',
+				exportName: 'clamp',
+				subpath: 'numbers',
+				example: `const clamped = clamp(150, 0, 100) // 100`,
+			},
+		],
+	},
+	text: {
+		name: '📝 Text Formatting',
+		functions: [
+			{
+				name: 'capitalize',
+				description: 'Capitalize first letter',
+				exportName: 'capitalize',
+				subpath: 'strings',
+				example: `const text = capitalize('hello world') // 'Hello world'`,
+			},
+			{
+				name: 'title',
+				description: 'Convert to title case',
+				exportName: 'titleCase',
+				subpath: 'strings',
+				example: `const heading = titleCase('hello world') // 'Hello World'`,
+			},
+			{
+				name: 'pad',
+				description: 'Pad with leading zeros',
+				exportName: 'padStart',
+				subpath: 'strings',
+				example: `const padded = padStart('42', 5, '0') // '00042'`,
+			},
+		],
+	},
+	file: {
+		name: '📁 File Operations',
+		functions: [
+			{
+				name: 'exists',
+				description: 'Check if file exists',
+				exportName: 'fileExists',
+				subpath: 'file',
+				example: `const exists = await fileExists('package.json') // true`,
+			},
+			{
+				name: 'ext',
+				description: 'Get file extension',
+				exportName: 'getFileExtension',
+				subpath: 'file',
+				example: `const extension = getFileExtension('file.txt') // '.txt'`,
+			},
+		],
+	},
+	security: {
+		name: '🔒 Security',
+		functions: [
+			{
+				name: 'password',
+				description: 'Check password strength',
+				exportName: 'isStrongPassword',
+				subpath: 'security',
+				example: `const isStrong = isStrongPassword('MyPass123!') // true`,
+			},
+			{
+				name: 'token',
+				description: 'Generate secure token',
+				exportName: 'generateSecureToken',
+				subpath: 'security',
+				example: `const token = generateSecureToken(32) // 64 hex chars`,
+			},
+		],
+	},
+	validate: {
+		name: '✅ Validation',
+		functions: [
+			{
+				name: 'url',
+				description: 'Validate URL format',
+				exportName: 'isUrl',
+				subpath: 'validation',
+				example: `const isValid = isUrl('https://example.com') // true`,
+			},
+		],
+	},
+	system: {
+		name: '💻 System Info',
+		functions: [
+			{
+				name: 'pid',
+				description: 'Get process ID',
+				exportName: 'getProcessId',
+				subpath: 'process',
+				example: `const processId = getProcessId() // 12345`,
+			},
+			{
+				name: 'uptime',
+				description: 'Get process uptime',
+				exportName: 'getProcessUptime',
+				subpath: 'process',
+				example: `const uptime = getProcessUptime() // 123.45`,
+			},
+			{
+				name: 'ci',
+				description: 'Check CI environment',
+				exportName: 'isCI',
+				subpath: 'process',
+				example: `const inCi = isCI() // false`,
+			},
+			{
+				name: 'node-version',
+				description: 'Get Node.js version',
+				exportName: 'getNodeMajorVersion',
+				subpath: 'node',
+				example: `const major = getNodeMajorVersion() // 22`,
+			},
+		],
+	},
+}
+
+export type CliFunction =
+	(typeof functionCategories)[keyof typeof functionCategories]['functions'][number]

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -7,6 +7,7 @@ import gradient from 'gradient-string'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { type CliFunction, functionCategories } from './catalog.js'
 
 // Get current directory
 const currentDir = dirname(fileURLToPath(import.meta.url))
@@ -18,73 +19,6 @@ program
 	.name('js-common')
 	.description(chalk.cyan('✨ CLI utilities from @rtorcato/js-common'))
 	.version(packageJson.version)
-
-// Function categories for list and interactive mode
-// `subpath` is the published module the printed import should name. It is not
-// always the category key — the CLI groups by task ('math', 'text', 'validate')
-// while the library groups by module ('numbers', 'strings', 'validation').
-const functionCategories = {
-	date: {
-		name: '📅 Date & Time',
-		subpath: 'date',
-		functions: [
-			{ name: 'today', description: "Get today's date (YYYY-MM-DD)" },
-			{ name: 'now', description: 'Get current timestamp' },
-			{ name: 'between', description: 'Calculate days between dates' },
-		],
-	},
-	math: {
-		name: '🔢 Mathematical',
-		subpath: 'numbers',
-		functions: [
-			{ name: 'sum', description: 'Calculate sum of numbers' },
-			{ name: 'avg', description: 'Calculate average of numbers' },
-			{ name: 'random', description: 'Generate random number' },
-			{ name: 'round', description: 'Round to decimal places' },
-			{ name: 'clamp', description: 'Clamp between min/max' },
-		],
-	},
-	text: {
-		name: '📝 Text Formatting',
-		subpath: 'strings',
-		functions: [
-			{ name: 'capitalize', description: 'Capitalize first letter' },
-			{ name: 'title', description: 'Convert to title case' },
-			{ name: 'pad', description: 'Pad with leading zeros' },
-		],
-	},
-	file: {
-		name: '📁 File Operations',
-		subpath: 'file',
-		functions: [
-			{ name: 'exists', description: 'Check if file exists' },
-			{ name: 'ext', description: 'Get file extension' },
-		],
-	},
-	security: {
-		name: '🔒 Security',
-		subpath: 'security',
-		functions: [
-			{ name: 'password', description: 'Check password strength' },
-			{ name: 'token', description: 'Generate secure token' },
-		],
-	},
-	validate: {
-		name: '✅ Validation',
-		subpath: 'validation',
-		functions: [{ name: 'url', description: 'Validate URL format' }],
-	},
-	system: {
-		name: '💻 System Info',
-		subpath: 'process',
-		functions: [
-			{ name: 'pid', description: 'Get process ID' },
-			{ name: 'uptime', description: 'Get process uptime' },
-			{ name: 'ci', description: 'Check CI environment' },
-			{ name: 'node-version', description: 'Get Node.js version' },
-		],
-	},
-}
 
 // List all functions - add as a separate command
 program
@@ -247,11 +181,11 @@ program
 			}
 
 			const selectedCategory = functionCategories[category as keyof typeof functionCategories]
-			const functions = await checkbox<string>({
+			const functions = await checkbox<CliFunction>({
 				message: chalk.cyan(`Select ${selectedCategory.name} functions to add:`),
 				choices: selectedCategory.functions.map((func) => ({
 					name: `${func.name} - ${func.description}`,
-					value: func.name,
+					value: func,
 					checked: false,
 				})),
 				pageSize: 10,
@@ -263,28 +197,32 @@ program
 				return
 			}
 
+			// A category can span several modules (math → numbers + random), so
+			// group by subpath and print one import per module.
+			const bySubpath = new Map<string, string[]>()
+			for (const func of functions) {
+				bySubpath.set(func.subpath, [...(bySubpath.get(func.subpath) ?? []), func.exportName])
+			}
+
 			console.log(chalk.green('\n📦 Import Statement:'))
-			console.log(
-				chalk.white(
-					`import { ${functions.join(', ')} } from '@rtorcato/js-common/${selectedCategory.subpath}'`
+			for (const [subpath, exportNames] of bySubpath) {
+				console.log(
+					chalk.white(`import { ${exportNames.join(', ')} } from '@rtorcato/js-common/${subpath}'`)
 				)
-			)
+			}
 
 			console.log(chalk.green('\n📝 Usage Examples:'))
-			functions.forEach((func: string) => {
-				const funcInfo = selectedCategory.functions.find((f) => f.name === func)
-				if (funcInfo) {
-					console.log(chalk.gray(`\n// ${funcInfo.description}`))
-					generateUsageExample(category, func)
-				}
-			})
+			for (const func of functions) {
+				console.log(chalk.gray(`\n// ${func.description}`))
+				console.log(chalk.white(func.example))
+			}
 
 			console.log(chalk.green('\n📚 Documentation:'))
 			console.log(chalk.blue(`https://github.com/rtorcato/js-common#${category}-utilities`))
 
 			console.log(
 				chalk.yellow('\n💡 Tip: Run ') +
-					chalk.green(`js-common ${category} ${functions[0]} --help`) +
+					chalk.green(`js-common ${category} ${functions[0]?.name} --help`) +
 					chalk.yellow(' for detailed CLI usage\n')
 			)
 		} catch (error) {
@@ -296,51 +234,6 @@ program
 			process.exit(1)
 		}
 	})
-
-// Helper function to generate usage examples
-function generateUsageExample(category: string, functionName: string) {
-	const examples: Record<string, Record<string, string>> = {
-		date: {
-			today: `const today = today(); // "${new Date().toISOString().split('T')[0]}"`,
-			now: `const timestamp = now(); // ${Date.now()}`,
-			between: `const days = daysBetween('2023-01-01', '2023-12-31'); // 364`,
-		},
-		math: {
-			sum: `const total = sum([1, 2, 3, 4, 5]); // 15`,
-			avg: `const average = avg([10, 20, 30]); // 20`,
-			random: `const num = randomBetween(1, 100); // 42`,
-			round: `const rounded = roundTo(3.14159, 2); // 3.14`,
-			clamp: `const clamped = clamp(150, 0, 100); // 100`,
-		},
-		text: {
-			capitalize: `const text = capitalize('hello world'); // "Hello world"`,
-			title: `const title = toTitleCase('hello world'); // "Hello World"`,
-			pad: `const padded = padWithZeros(42, 5); // "00042"`,
-		},
-		file: {
-			exists: `const exists = await fileExists('package.json'); // true`,
-			ext: `const extension = getFileExtension('file.txt'); // "txt"`,
-		},
-		security: {
-			password: `const isStrong = checkPasswordStrength('MyPass123!'); // true`,
-			token: `const token = generateSecureToken(32); // "abc123..."`,
-		},
-		validate: {
-			url: `const isValid = isValidUrl('https://example.com'); // true`,
-		},
-		system: {
-			pid: `const processId = getProcessId(); // 12345`,
-			uptime: `const uptime = getProcessUptime(); // 123.45`,
-			ci: `const isCI = isCiEnvironment(); // false`,
-			'node-version': `const version = getNodeVersion(); // "18.17.0"`,
-		},
-	}
-
-	const example = examples[category]?.[functionName]
-	if (example) {
-		console.log(chalk.white(example))
-	}
-}
 
 // Date commands
 const dateCmd = program.command('date').description('📅 Date and time utilities')


### PR DESCRIPTION
`js-common add` built its printed import and usage examples from the CLI **verb** names, not the library export names — so every import it emitted was unusable (`avg`, `random`, `title`, `pad`, `now`, `exists`, `ci`, …).

## What changed

- Each catalog entry now carries an explicit `exportName` and `subpath`; the import statement and the usage example are both built from those.
- A category can span modules, so `add` groups the selection by subpath and prints one import line per module — e.g. picking `today`, `now`, `between` now prints:

  ```
  import { today, daysBetween } from '@rtorcato/js-common/date'
  import { nowIso } from '@rtorcato/js-common/datetime'
  ```

- The catalog moved to `src/cli/catalog.ts` so `src/cli/catalog.test.ts` can assert every `exportName` really is exported by `src/<subpath>/index.ts` (20 entries, all green). That is the guard against future drift.
- `generateUsageExample()` deleted — each example now lives on the entry next to the name it uses, so the two can't disagree.

## Verified

- `tsc --noEmit`, `biome check .`, `vitest run` (402 passed) all clean.
- `pnpm run build-cli` emits `dist/cli/catalog.js` alongside `cli.mjs` and the binary runs (`list`, `date today`, and `add` driven through a pty to confirm the grouped import output above). Package is `type: module`, so the extra emitted `.js` resolves as ESM without touching the build script.

Closes #186