### PR TITLE
docs(skills): fix fabricated helper names and guard the files in CI

### DIFF
--- a/.github/skills/advanced-patterns.md
+++ b/.github/skills/advanced-patterns.md
@@ -55,17 +55,18 @@ class ApiClient {
     return isSuccess(result) ? result.data : null
   }
 
-  async createSecureSession(credentials: LoginCredentials) {
-    const { data: sessionData, error } = await tryCatch(async () => {
-      const hashedPassword = hashString(credentials.password, 'sha256')
-      return await this.authenticateUser({
-        ...credentials,
-        password: hashedPassword,
-        createdOn: formatDate(new Date())
+  async syncProfile(profile: UserProfile) {
+    const { data, error } = await tryCatch(async () => {
+      // Content fingerprint — skip the write when nothing actually changed
+      const fingerprint = hashString(JSON.stringify(profile), 'sha256')
+      return await this.upsertProfile({
+        ...profile,
+        fingerprint,
+        syncedOn: formatDate(new Date())
       })
     })
 
-    return error ? { error } : { session: sessionData }
+    return error ? { error } : { profile: data }
   }
 }
 ```

--- a/.github/skills/advanced-patterns.md
+++ b/.github/skills/advanced-patterns.md
@@ -2,63 +2,69 @@
 
 This file contains advanced patterns and compositions using `@rtorcato/js-common` to help GitHub Copilot suggest more sophisticated code patterns.
 
+Every import below names a module subpath. The package root is empty by design —
+see rule 1 of `AGENTS.md`.
+
 ## Functional Composition Patterns
 
 ### Data Processing Pipelines
 ```typescript
-import { 
-  chunk, unique, compact, groupBy, 
-  pick, omit, deepMerge,
-  isEmail, isEmpty, isLength,
-  attempt, trycatch
-} from '@rtorcato/js-common'
+import { groupBy } from '@rtorcato/js-common/arrays'
+import { deepMerge, pick } from '@rtorcato/js-common/objects'
+import { isBlank } from '@rtorcato/js-common/strings'
+import { tryCatch } from '@rtorcato/js-common/try'
+import { isEmail } from '@rtorcato/js-common/validation'
 
 // Pattern: User data processing pipeline
 async function processUserData(users: RawUser[]) {
-  return await attempt(async () => {
-    return users
-      .filter(user => !isEmpty(user.email) && isEmail(user.email))
-      .map(user => pick(user, ['id', 'email', 'name', 'preferences']))
-      .map(user => ({
+  return await tryCatch(async () => {
+    const cleaned = users
+      .filter((user) => !isBlank(user.email) && isEmail(user.email))
+      .map((user) => pick(user, ['id', 'email', 'name', 'preferences']))
+      .map((user) => ({
         ...user,
         preferences: deepMerge(defaultPreferences, user.preferences || {})
       }))
-      .reduce((acc, user) => groupBy(acc, user => user.preferences.region), [])
+
+    return groupBy(cleaned, (user) => user.preferences.region)
   })
 }
 ```
 
 ### Error-Safe API Calls
 ```typescript
-import { attempt, formatDate, isUrl, hash } from '@rtorcato/js-common'
+import { hashString } from '@rtorcato/js-common/crypto'
+import { formatDate } from '@rtorcato/js-common/date'
+import { isBlank } from '@rtorcato/js-common/strings'
+import { isSuccess, tryCatch } from '@rtorcato/js-common/try'
 
 // Pattern: Robust API client with error handling
 class ApiClient {
   async fetchUser(id: string) {
-    const result = await attempt(async () => {
-      if (isEmpty(id)) throw new Error('ID required')
-      
+    const result = await tryCatch(async () => {
+      if (isBlank(id)) throw new Error('ID required')
+
       const response = await fetch(`/api/users/${id}`)
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
       }
-      
+
       return response.json()
     })
-    
-    return result.success ? result.data : null
+
+    return isSuccess(result) ? result.data : null
   }
-  
+
   async createSecureSession(credentials: LoginCredentials) {
-    const [error, sessionData] = await trycatch(async () => {
-      const hashedPassword = await hash(credentials.password, 'sha256')
+    const { data: sessionData, error } = await tryCatch(async () => {
+      const hashedPassword = hashString(credentials.password, 'sha256')
       return await this.authenticateUser({
         ...credentials,
         password: hashedPassword,
-        timestamp: formatDate(new Date(), 'YYYY-MM-DD HH:mm:ss')
+        createdOn: formatDate(new Date())
       })
     })
-    
+
     return error ? { error } : { session: sessionData }
   }
 }
@@ -66,36 +72,38 @@ class ApiClient {
 
 ### Validation Chains
 ```typescript
-import { isEmail, isLength, isEmpty, isUrl, isUuid } from '@rtorcato/js-common/validation'
+import { isBlank } from '@rtorcato/js-common/strings'
+import { isUUID } from '@rtorcato/js-common/uuid'
+import { isEmail, isUrl } from '@rtorcato/js-common/validation'
 
 // Pattern: Comprehensive validation with error accumulation
 function validateUserProfile(profile: UserProfile): ValidationResult {
   const errors: string[] = []
-  
+
   // Email validation chain
-  if (isEmpty(profile.email)) {
+  if (isBlank(profile.email)) {
     errors.push('Email is required')
   } else if (!isEmail(profile.email)) {
     errors.push('Invalid email format')
   }
-  
+
   // Password validation chain
-  if (isEmpty(profile.password)) {
+  if (isBlank(profile.password)) {
     errors.push('Password is required')
-  } else if (!isLength(profile.password, 8)) {
+  } else if (profile.password.length < 8) {
     errors.push('Password must be at least 8 characters')
   }
-  
+
   // Optional URL validation
   if (profile.website && !isUrl(profile.website)) {
     errors.push('Invalid website URL')
   }
-  
+
   // ID validation if provided
-  if (profile.id && !isUuid(profile.id)) {
+  if (profile.id && !isUUID(profile.id)) {
     errors.push('Invalid ID format')
   }
-  
+
   return {
     isValid: errors.length === 0,
     errors,
@@ -106,27 +114,28 @@ function validateUserProfile(profile: UserProfile): ValidationResult {
 
 ### Batch Processing with Performance
 ```typescript
-import { chunk, flatten, unique, attempt } from '@rtorcato/js-common'
+import { chunk, flatten, unique } from '@rtorcato/js-common/arrays'
+import { isSuccess, tryCatch } from '@rtorcato/js-common/try'
 
 // Pattern: Batch processing for performance
 async function processBatchData<T, U>(
-  items: T[], 
+  items: T[],
   processor: (batch: T[]) => Promise<U[]>,
   batchSize: number = 50
 ): Promise<U[]> {
   const batches = chunk(items, batchSize)
   const results: U[][] = []
-  
+
   // Process batches sequentially to avoid overwhelming APIs
   for (const batch of batches) {
-    const result = await attempt(() => processor(batch))
-    if (result.success) {
+    const result = await tryCatch(() => processor(batch))
+    if (isSuccess(result)) {
       results.push(result.data)
     } else {
-      console.warn(`Batch processing failed:`, result.error)
+      console.warn('Batch processing failed:', result.error)
     }
   }
-  
+
   return flatten(results)
 }
 
@@ -136,7 +145,7 @@ async function syncUsers(users: User[]) {
     unique(users), // Remove duplicates first
     async (batch) => {
       return await Promise.all(
-        batch.map(user => syncUserToDatabase(user))
+        batch.map((user) => syncUserToDatabase(user))
       )
     },
     25 // Process 25 users at a time
@@ -146,7 +155,9 @@ async function syncUsers(users: User[]) {
 
 ### Configuration Management
 ```typescript
-import { getEnv, requireEnv, isEmpty, isUrl } from '@rtorcato/js-common'
+import { getENV } from '@rtorcato/js-common/env'
+import { isBlank } from '@rtorcato/js-common/strings'
+import { isUrl } from '@rtorcato/js-common/validation'
 
 // Pattern: Type-safe configuration with validation
 class AppConfig {
@@ -155,15 +166,128 @@ class AppConfig {
   readonly apiKey: string
   readonly debugMode: boolean
   readonly allowedOrigins: string[]
-  
+
   constructor() {
-    // Required environment variables
-    this.databaseUrl = requireEnv('DATABASE_URL')
-    this.apiKey = requireEnv('API_KEY')
-    
+    // Required environment variables — getENV throws when there is no default
+    this.databaseUrl = getENV('DATABASE_URL')
+    this.apiKey = getENV('API_KEY')
+
     // Optional with defaults
-    this.port = parseInt(getEnv('PORT', '3000'))
-    this.debugMode = getEnv('NODE_ENV', 'production') !== 'production'
-    
+    this.port = Number.parseInt(getENV('PORT', '3000'))
+    this.debugMode = getENV('NODE_ENV', 'production') !== 'production'
+
     // Parse arrays from environment
-    const origins = getEnv('ALLOWED_ORIGINS', '')\n    this.allowedOrigins = isEmpty(origins) \n      ? ['http://localhost:3000']\n      : origins.split(',').filter(isUrl)\n    \n    this.validate()\n  }\n  \n  private validate() {\n    if (!isUrl(this.databaseUrl)) {\n      throw new Error('Invalid DATABASE_URL format')\n    }\n    \n    if (isEmpty(this.apiKey)) {\n      throw new Error('API_KEY cannot be empty')\n    }\n    \n    if (this.port < 1 || this.port > 65535) {\n      throw new Error('PORT must be between 1 and 65535')\n    }\n  }\n}\n```\n\n### Reactive Data Transformations\n```typescript\nimport { groupBy, pick, formatCurrency, formatDate } from '@rtorcato/js-common'\n\n// Pattern: Reactive data transformation pipeline\nclass DataTransformer {\n  static transformOrdersForDisplay(orders: Order[]) {\n    return orders\n      .map(order => ({\n        ...pick(order, ['id', 'customerId', 'status']),\n        total: formatCurrency(order.amount, 'USD'),\n        date: formatDate(order.createdAt, 'MMM DD, YYYY'),\n        items: order.items?.length || 0\n      }))\n      .reduce(groupBy, order => order.status)\n  }\n  \n  static aggregateUserMetrics(users: User[], period: 'daily' | 'weekly' | 'monthly') {\n    const dateFormat = {\n      daily: 'YYYY-MM-DD',\n      weekly: 'YYYY-[W]WW', \n      monthly: 'YYYY-MM'\n    }[period]\n    \n    return users\n      .filter(user => user.active)\n      .map(user => ({\n        ...user,\n        period: formatDate(user.lastLoginAt, dateFormat)\n      }))\n      .reduce(groupBy, user => user.period)\n  }\n}\n```\n\n### Type-Safe Event Handling\n```typescript\nimport { attempt, isEmpty, isLength } from '@rtorcato/js-common'\n\n// Pattern: Event-driven architecture with validation\nclass EventProcessor {\n  async processUserEvent(event: UserEvent) {\n    const result = await attempt(async () => {\n      // Validate event structure\n      if (isEmpty(event.type) || isEmpty(event.userId)) {\n        throw new Error('Invalid event structure')\n      }\n      \n      // Process based on event type\n      switch (event.type) {\n        case 'user.created':\n          return this.handleUserCreated(event.data)\n        case 'user.updated':\n          return this.handleUserUpdated(event.data)\n        case 'user.deleted':\n          return this.handleUserDeleted(event.data)\n        default:\n          throw new Error(`Unknown event type: ${event.type}`)\n      }\n    })\n    \n    if (!result.success) {\n      await this.logEventError(event, result.error)\n    }\n    \n    return result\n  }\n}\n```\n\n## Copilot Enhancement Patterns\n\nWhen GitHub Copilot sees these imports together, it should suggest:\n\n1. **Error handling patterns** with `attempt` and `trycatch`\n2. **Validation chains** with multiple `is*` functions\n3. **Data transformation pipelines** combining array and object utilities\n4. **Batch processing** for performance with `chunk`\n5. **Type-safe configuration** with environment utilities\n6. **Functional composition** chaining multiple utilities\n\nThese patterns help developers write more robust, maintainable code using the js-common library.
+    const origins = getENV('ALLOWED_ORIGINS', '')
+    this.allowedOrigins = isBlank(origins)
+      ? ['http://localhost:3000']
+      : origins.split(',').filter(isUrl)
+
+    this.validate()
+  }
+
+  private validate() {
+    if (!isUrl(this.databaseUrl)) {
+      throw new Error('Invalid DATABASE_URL format')
+    }
+
+    if (isBlank(this.apiKey)) {
+      throw new Error('API_KEY cannot be empty')
+    }
+
+    if (this.port < 1 || this.port > 65535) {
+      throw new Error('PORT must be between 1 and 65535')
+    }
+  }
+}
+```
+
+For a whole environment validated in one pass, use `checkEnv` with a Zod schema
+instead — it throws once, listing every missing key:
+
+```typescript
+import { checkEnv } from '@rtorcato/js-common/env'
+
+const env = checkEnv(schema, process.env)
+```
+
+### Reactive Data Transformations
+```typescript
+import { groupBy } from '@rtorcato/js-common/arrays'
+import { formatPrice } from '@rtorcato/js-common/currency'
+import { formatDate } from '@rtorcato/js-common/date'
+import { pick } from '@rtorcato/js-common/objects'
+
+// Pattern: Reactive data transformation pipeline
+class DataTransformer {
+  static transformOrdersForDisplay(orders: Order[]) {
+    const rows = orders.map((order) => ({
+      ...pick(order, ['id', 'customerId', 'status']),
+      total: formatPrice(order.amount, 'USD'),
+      date: formatDate(order.createdAt),
+      items: order.items?.length || 0
+    }))
+
+    return groupBy(rows, (order) => order.status)
+  }
+
+  static aggregateUserMetrics(users: User[]) {
+    const active = users
+      .filter((user) => user.active)
+      .map((user) => ({
+        ...user,
+        day: formatDate(user.lastLoginAt)
+      }))
+
+    return groupBy(active, (user) => user.day)
+  }
+}
+```
+
+### Type-Safe Event Handling
+```typescript
+import { isBlank } from '@rtorcato/js-common/strings'
+import { isSuccess, tryCatch } from '@rtorcato/js-common/try'
+
+// Pattern: Event-driven architecture with validation
+class EventProcessor {
+  async processUserEvent(event: UserEvent) {
+    const result = await tryCatch(async () => {
+      // Validate event structure
+      if (isBlank(event.type) || isBlank(event.userId)) {
+        throw new Error('Invalid event structure')
+      }
+
+      // Process based on event type
+      switch (event.type) {
+        case 'user.created':
+          return this.handleUserCreated(event.data)
+        case 'user.updated':
+          return this.handleUserUpdated(event.data)
+        case 'user.deleted':
+          return this.handleUserDeleted(event.data)
+        default:
+          throw new Error(`Unknown event type: ${event.type}`)
+      }
+    })
+
+    if (!isSuccess(result)) {
+      await this.logEventError(event, result.error)
+    }
+
+    return result
+  }
+}
+```
+
+## Copilot Enhancement Patterns
+
+When GitHub Copilot sees these imports together, it should suggest:
+
+1. **Error handling patterns** with `tryCatch` and `isSuccess`
+2. **Validation chains** with multiple `is*` functions
+3. **Data transformation pipelines** combining array and object utilities
+4. **Batch processing** for performance with `chunk`
+5. **Type-safe configuration** with environment utilities
+6. **Functional composition** chaining multiple utilities
+
+These patterns help developers write more robust, maintainable code using the js-common library.

--- a/.github/skills/javascript-utilities.md
+++ b/.github/skills/javascript-utilities.md
@@ -184,9 +184,16 @@ When suggesting code using this library:
 ### API Endpoint with Validation
 ```typescript
 import { hashString } from '@rtorcato/js-common/crypto'
+import { normalizeEmail } from '@rtorcato/js-common/emails'
 import { isBlank } from '@rtorcato/js-common/strings'
 import { tryCatch } from '@rtorcato/js-common/try'
 import { isEmail } from '@rtorcato/js-common/validation'
+
+type CreateUserRequest = {
+  email: string
+  displayName: string
+  locale: string
+}
 
 async function createUser(data: CreateUserRequest) {
   // Validate input
@@ -195,7 +202,7 @@ async function createUser(data: CreateUserRequest) {
   }
 
   // Stable lookup key for the normalized email — a digest, not a credential
-  const emailKey = hashString(data.email.trim().toLowerCase())
+  const emailKey = hashString(normalizeEmail(data.email))
 
   // Safe database operation
   const { data: user, error } = await tryCatch(async () => {
@@ -209,6 +216,10 @@ async function createUser(data: CreateUserRequest) {
   return user
 }
 ```
+
+`CreateUserRequest` deliberately carries no credential field. Credentials never
+belong in a profile payload that gets spread into a write — hash them in a
+dedicated auth flow with bcrypt, scrypt or argon2.
 
 ### Data Processing Pipeline
 ```typescript

--- a/.github/skills/javascript-utilities.md
+++ b/.github/skills/javascript-utilities.md
@@ -69,13 +69,18 @@ const uuid = isUUID('550e8400-e29b-41d4-a716-446655440000') // boolean
 import { base64Encode, hashString, hmacHash, randomHex } from '@rtorcato/js-common/crypto'
 
 // Hashing — synchronous, returns a hex digest
-const hashed = hashString('password', 'sha256')
+const cacheKey = hashString(`user:${userId}:${locale}`)
+const etag = hashString(JSON.stringify(payload), 'sha256')
 const signature = hmacHash('payload', process.env.SECRET)
 
 // Random bytes as hex
 const token = randomHex(32)
 const encoded = base64Encode('hello')
 ```
+
+`hashString` is a plain, unsalted digest — for cache keys, content fingerprints,
+ETags and dedupe keys. It is not a password hash: use bcrypt, scrypt or argon2
+for credentials, never a raw SHA-256.
 
 For random strings from a chosen alphabet, use the `random` module instead:
 
@@ -171,7 +176,8 @@ When suggesting code using this library:
 5. **Chain utilities** when appropriate for functional composition
 6. **Include error handling** for async operations using `try` utilities
 7. **Suggest validation** before processing user input
-8. **Recommend crypto utilities** for security-sensitive operations
+8. **Recommend crypto utilities** for digests, signing and random tokens — never
+   for password storage, which needs bcrypt/scrypt/argon2
 
 ## Integration Examples
 
@@ -188,14 +194,14 @@ async function createUser(data: CreateUserRequest) {
     throw new Error('Invalid email')
   }
 
-  // Hash password
-  const hashedPassword = hashString(data.password, 'sha256')
+  // Stable lookup key for the normalized email — a digest, not a credential
+  const emailKey = hashString(data.email.trim().toLowerCase())
 
   // Safe database operation
   const { data: user, error } = await tryCatch(async () => {
     return await database.users.create({
       ...data,
-      password: hashedPassword
+      emailKey
     })
   })
 

--- a/.github/skills/javascript-utilities.md
+++ b/.github/skills/javascript-utilities.md
@@ -4,110 +4,154 @@ This document provides context and patterns for GitHub Copilot to better underst
 
 ## Library Overview
 
-`@rtorcato/js-common` is a comprehensive TypeScript utility library providing 30+ modules for common JavaScript operations. All functions are tree-shakeable, type-safe, and follow functional programming patterns.
+`@rtorcato/js-common` is a comprehensive TypeScript utility library providing 40+ modules for common JavaScript operations. All functions are tree-shakeable, type-safe, and follow functional programming patterns.
+
+Every helper is imported from its module subpath — `@rtorcato/js-common/arrays`, not the package root. Each name has exactly one home (see `MODULE-BOUNDARIES.md`), so the subpath tells you where a helper lives.
 
 ## Core Patterns
 
 ### Array Utilities
 ```typescript
-import { unique, chunk, flatten, groupBy } from '@rtorcato/js-common/arrays'
+import { chunk, flatten, groupBy, unique } from '@rtorcato/js-common/arrays'
 
 // Remove duplicates with type safety
 const numbers = unique([1, 2, 2, 3]) // number[]
 const strings = unique(['a', 'b', 'a']) // string[]
 
-// Group arrays by key
+// Group arrays by a computed key — the second argument is a function
 const users = [{ id: 1, role: 'admin' }, { id: 2, role: 'user' }]
-const grouped = groupBy(users, 'role') // { admin: [user], user: [user] }
+const grouped = groupBy(users, (user) => user.role) // { admin: [...], user: [...] }
 
 // Chunk arrays into smaller pieces
 const chunked = chunk([1, 2, 3, 4, 5], 2) // [[1, 2], [3, 4], [5]]
+
+// Flatten one level
+const flat = flatten([[1, 2], [3, 4]]) // [1, 2, 3, 4]
 ```
 
 ### String Utilities
 ```typescript
-import { capitalize, kebabCase, camelCase, truncate } from '@rtorcato/js-common/strings'
+import { camelCase, capitalize, isBlank, kebabCase, titleCase, truncate } from '@rtorcato/js-common/strings'
 
 // Case transformations
-const title = capitalize('hello world') // 'Hello World'
+const upperFirst = capitalize('hello world') // 'Hello world' — first character only
+const title = titleCase('hello world') // 'Hello World'
 const kebab = kebabCase('Hello World') // 'hello-world'
 const camel = camelCase('hello-world') // 'helloWorld'
 
 // Text manipulation
 const short = truncate('Long text here', 10) // 'Long te...'
+
+// Blank check — empty or whitespace-only
+const blank = isBlank('   ') // true
 ```
 
 ### Validation Utilities
 ```typescript
-import { isEmail, isUrl, isUuid, isEmpty } from '@rtorcato/js-common/validation'
+import { isDefined, isEmail, isString, isUrl } from '@rtorcato/js-common/validation'
 
 // Type-safe validation
 const email = isEmail('user@example.com') // boolean
 const url = isUrl('https://example.com') // boolean
-const uuid = isUuid('550e8400-e29b-41d4-a716-446655440000') // boolean
+const defined = isDefined(value) // narrows away null | undefined
+```
+
+UUIDs live in their own module:
+
+```typescript
+import { isUUID } from '@rtorcato/js-common/uuid'
+
+const uuid = isUUID('550e8400-e29b-41d4-a716-446655440000') // boolean
 ```
 
 ### Crypto Utilities
 ```typescript
-import { hash, randomString, encrypt, decrypt } from '@rtorcato/js-common/crypto'
+import { base64Encode, hashString, hmacHash, randomHex } from '@rtorcato/js-common/crypto'
 
-// Secure hashing and random generation
-const hashed = await hash('password', 'sha256')
-const token = randomString(32) // Random string of 32 characters
+// Hashing — synchronous, returns a hex digest
+const hashed = hashString('password', 'sha256')
+const signature = hmacHash('payload', process.env.SECRET)
+
+// Random bytes as hex
+const token = randomHex(32)
+const encoded = base64Encode('hello')
+```
+
+For random strings from a chosen alphabet, use the `random` module instead:
+
+```typescript
+import { randomString } from '@rtorcato/js-common/random'
+
+const id = randomString(32) // Random string of 32 characters
 ```
 
 ### Date/Time Utilities
 ```typescript
-import { formatDate, parseDate, addDays, diffDays } from '@rtorcato/js-common/date'
+import { addDays, daysBetween, formatDate, parseDate } from '@rtorcato/js-common/date'
 
 // Date manipulation
-const formatted = formatDate(new Date(), 'YYYY-MM-DD')
+const formatted = formatDate(new Date()) // 'YYYY-MM-DD'
+const parsed = parseDate('2023-05-26') // Date
 const future = addDays(new Date(), 7) // 7 days from now
-const diff = diffDays(date1, date2) // Difference in days
+const diff = daysBetween(date1, date2) // Difference in days
 ```
 
 ## Common Usage Patterns
 
 ### Error Handling with Try Utilities
 ```typescript
-import { attempt, trycatch } from '@rtorcato/js-common/try'
+import { isSuccess, tryCatch } from '@rtorcato/js-common/try'
 
-// Safe function execution
-const result = await attempt(async () => {
+// Safe async execution — returns a Go-style { data, error } Result
+const result = await tryCatch(async () => {
   return await riskyOperation()
 })
-if (result.success) {
+if (isSuccess(result)) {
   console.log(result.data)
 } else {
   console.error(result.error)
 }
 
-// Traditional try-catch wrapper
-const [error, data] = await trycatch(riskyOperation())
+// Destructuring reads well when you only need one branch
+const { data, error } = await tryCatch(() => fetch('/api/user').then((r) => r.json()))
+if (error) return console.error(error)
 ```
 
 ### Environment Configuration
 ```typescript
-import { getEnv, requireEnv } from '@rtorcato/js-common/env'
+import { checkEnv, getENV } from '@rtorcato/js-common/env'
 
-// Environment variables with defaults
-const port = getEnv('PORT', '3000') // string
-const apiKey = requireEnv('API_KEY') // throws if missing
+// Single variables — a default makes it optional, no default makes it required
+const port = getENV('PORT', '3000') // string, falls back to '3000'
+const apiKey = getENV('API_KEY') // throws if undefined
+
+// Whole-environment validation against a Zod schema, throwing with every
+// missing key listed at once
+const env = checkEnv(schema, process.env)
 ```
 
 ### Number Utilities
 ```typescript
-import { clamp, round, random, formatCurrency } from '@rtorcato/js-common/numbers'
+import { between, clamp, roundTo, sum } from '@rtorcato/js-common/numbers'
 
 // Math operations
 const clamped = clamp(150, 0, 100) // 100
-const rounded = round(3.14159, 2) // 3.14
-const randomNum = random(1, 10) // Random number between 1 and 10
+const rounded = roundTo(3.14159, 2) // 3.14 — second argument is the decimal places, default 2
+const inRange = between(5, 1, 10) // true
+const total = sum([1, 2, 3]) // 6
+```
+
+Currency formatting lives in the `currency` module:
+
+```typescript
+import { formatPrice } from '@rtorcato/js-common/currency'
+
+const price = formatPrice(1234.56, 'USD') // '$1,234.56'
 ```
 
 ### Object Utilities
 ```typescript
-import { pick, omit, deepMerge, deepClone } from '@rtorcato/js-common/objects'
+import { deepClone, deepMerge, omit, pick } from '@rtorcato/js-common/objects'
 
 // Object manipulation
 const picked = pick(user, ['name', 'email'])
@@ -120,58 +164,60 @@ const cloned = deepClone(complexObject)
 
 When suggesting code using this library:
 
-1. **Always import specific functions** rather than the entire module
-2. **Preserve TypeScript generics** for type safety
-3. **Use descriptive variable names** that match the function purpose
-4. **Chain utilities** when appropriate for functional composition
-5. **Include error handling** for async operations using `try` utilities
-6. **Suggest validation** before processing user input
-7. **Recommend crypto utilities** for security-sensitive operations
+1. **Import from the module subpath**, never the package root — the root entry is intentionally empty
+2. **Import specific functions** rather than the entire module
+3. **Preserve TypeScript generics** for type safety
+4. **Use descriptive variable names** that match the function purpose
+5. **Chain utilities** when appropriate for functional composition
+6. **Include error handling** for async operations using `try` utilities
+7. **Suggest validation** before processing user input
+8. **Recommend crypto utilities** for security-sensitive operations
 
 ## Integration Examples
 
 ### API Endpoint with Validation
 ```typescript
-import { isEmail, isEmpty } from '@rtorcato/js-common/validation'
-import { hash } from '@rtorcato/js-common/crypto'
-import { attempt } from '@rtorcato/js-common/try'
+import { hashString } from '@rtorcato/js-common/crypto'
+import { isBlank } from '@rtorcato/js-common/strings'
+import { tryCatch } from '@rtorcato/js-common/try'
+import { isEmail } from '@rtorcato/js-common/validation'
 
 async function createUser(data: CreateUserRequest) {
   // Validate input
-  if (isEmpty(data.email) || !isEmail(data.email)) {
+  if (isBlank(data.email) || !isEmail(data.email)) {
     throw new Error('Invalid email')
   }
-  
-  // Hash password securely
-  const hashedPassword = await hash(data.password, 'sha256')
-  
+
+  // Hash password
+  const hashedPassword = hashString(data.password, 'sha256')
+
   // Safe database operation
-  const result = await attempt(async () => {
+  const { data: user, error } = await tryCatch(async () => {
     return await database.users.create({
       ...data,
       password: hashedPassword
     })
   })
-  
-  return result
+
+  if (error) throw error
+  return user
 }
 ```
 
 ### Data Processing Pipeline
 ```typescript
-import { chunk, flatten } from '@rtorcato/js-common/arrays'
-import { formatCurrency } from '@rtorcato/js-common/numbers'
+import { chunk } from '@rtorcato/js-common/arrays'
+import { formatPrice } from '@rtorcato/js-common/currency'
 import { formatDate } from '@rtorcato/js-common/date'
 
 function processOrderData(orders: Order[]) {
-  return orders
-    .map(order => ({
-      ...order,
-      total: formatCurrency(order.amount),
-      date: formatDate(order.createdAt, 'YYYY-MM-DD')
-    }))
-    .pipe(orders => chunk(orders, 50)) // Process in batches
-    .pipe(flatten) // Flatten back to single array
+  const formatted = orders.map((order) => ({
+    ...order,
+    total: formatPrice(order.amount, 'USD'),
+    date: formatDate(order.createdAt)
+  }))
+
+  return chunk(formatted, 50) // Process in batches
 }
 ```
 

--- a/.github/skills/typescript-patterns.md
+++ b/.github/skills/typescript-patterns.md
@@ -7,20 +7,16 @@ This file provides GitHub Copilot with specific TypeScript patterns used through
 ### Array Manipulation Functions
 ```typescript
 // Pattern: Generic array transformation
-export function transform<T, U>(arr: T[], fn: (item: T) => U): U[] {
+export function mapItems<T, U>(arr: T[], fn: (item: T) => U): U[] {
   return arr.map(fn)
 }
 
-// Pattern: Array filtering with type guards
-export function filterBy<T>(arr: T[], predicate: (item: T) => boolean): T[] {
-  return arr.filter(predicate)
-}
-
-// Pattern: Array grouping with computed keys
-export function groupBy<T, K extends string | number>(
-  arr: T[], 
-  key: keyof T | ((item: T) => K)
-): Record<K, T[]> {
+// Pattern: Array grouping with a computed key — js-common's `groupBy` takes a
+// key function, not a property name
+export function groupBy<T>(
+  arr: T[],
+  fn: (item: T) => string | number
+): Record<string | number, T[]> {
   // Implementation details...
 }
 ```
@@ -28,14 +24,14 @@ export function groupBy<T, K extends string | number>(
 ### Object Manipulation Patterns
 ```typescript
 // Pattern: Object key picking with type safety
-export function pick<T, K extends keyof T>(obj: T, keys: K[]): Pick<T, K> {
+export function pick<T extends object, K extends keyof T>(obj: T, keys: K[]): Pick<T, K> {
   // Implementation...
 }
 
 // Pattern: Object merging with deep type inference
-export function merge<T extends Record<string, any>, U extends Record<string, any>>(
-  obj1: T,
-  obj2: U
+export function deepMerge<T extends object, U extends object>(
+  target: T,
+  source: U
 ): T & U {
   // Implementation...
 }
@@ -51,24 +47,21 @@ export function isString(value: unknown): value is string {
 export function isArray<T>(value: unknown): value is T[] {
   return Array.isArray(value)
 }
-
-// Pattern: Schema validation with type inference
-export function validate<T>(value: unknown, schema: Schema<T>): value is T {
-  // Implementation...
-}
 ```
 
 ### Async Utility Patterns
 ```typescript
-// Pattern: Safe async execution with error handling
-export async function attempt<T>(
-  fn: () => Promise<T>
-): Promise<{ success: true; data: T } | { success: false; error: Error }> {
+// Pattern: Go-style Result instead of a thrown exception
+export type Success<T> = { data: T; error: null }
+export type Failure<E> = { data: null; error: E }
+export type Result<T, E = Error> = Success<T> | Failure<E>
+
+export async function tryCatch<T, E = Error>(fn: () => Promise<T>): Promise<Result<T, E>> {
   try {
     const data = await fn()
-    return { success: true, data }
+    return { data, error: null }
   } catch (error) {
-    return { success: false, error: error as Error }
+    return { data: null, error: error as E }
   }
 }
 
@@ -83,14 +76,6 @@ export function withTimeout<T>(
 
 ### String Processing Patterns
 ```typescript
-// Pattern: String case transformations
-export function transform<T extends string>(
-  str: T,
-  transformer: (s: string) => string
-): string {
-  return transformer(str)
-}
-
 // Pattern: Template string processing
 export function template(
   str: string,
@@ -104,7 +89,8 @@ export function template(
 
 ### Data Processing Pipeline
 ```typescript
-import { groupBy, pick, filterBy } from '@rtorcato/js-common'
+import { groupBy } from '@rtorcato/js-common/arrays'
+import { pick } from '@rtorcato/js-common/objects'
 
 interface User {
   id: number
@@ -116,51 +102,54 @@ interface User {
 
 // Copilot should suggest this pattern for user data processing
 function processUsers(users: User[]) {
-  return filterBy(users, user => user.active)
-    .map(user => pick(user, ['id', 'name', 'email']))
-    .reduce(groupBy, user => user.role)
+  const active = users
+    .filter((user) => user.active)
+    .map((user) => pick(user, ['id', 'name', 'email', 'role']))
+
+  return groupBy(active, (user) => user.role)
 }
 ```
 
 ### Error Handling Pipeline
 ```typescript
-import { attempt, trycatch } from '@rtorcato/js-common/try'
+import { isSuccess, tryCatch } from '@rtorcato/js-common/try'
 
 // Pattern for API calls with error handling
 async function fetchUserData(userId: string) {
-  const result = await attempt(async () => {
+  const result = await tryCatch(async () => {
     const response = await fetch(`/api/users/${userId}`)
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`)
     }
     return response.json()
   })
-  
-  if (result.success) {
+
+  if (isSuccess(result)) {
     return result.data
-  } else {
-    console.error('Failed to fetch user:', result.error.message)
-    return null
   }
+
+  console.error('Failed to fetch user:', result.error.message)
+  return null
 }
 ```
 
 ### Validation Chain
 ```typescript
-import { isEmail, isEmpty, isLength } from '@rtorcato/js-common/validation'
+import { isBlank } from '@rtorcato/js-common/strings'
+import { isEmail } from '@rtorcato/js-common/validation'
 
 // Pattern for input validation
 function validateUserInput(input: { email: string; password: string }) {
   const errors: string[] = []
-  
-  if (isEmpty(input.email) || !isEmail(input.email)) {
+
+  if (isBlank(input.email) || !isEmail(input.email)) {
     errors.push('Invalid email address')
   }
-  
-  if (isEmpty(input.password) || !isLength(input.password, 8)) {
+
+  if (isBlank(input.password) || input.password.length < 8) {
     errors.push('Password must be at least 8 characters')
   }
-  
+
   return {
     isValid: errors.length === 0,
     errors
@@ -173,24 +162,29 @@ function validateUserInput(input: { email: string; password: string }) {
 When Copilot encounters these imports, suggest these patterns:
 
 ### Import Suggestions
-- `@rtorcato/js-common/arrays` → suggest `unique`, `chunk`, `groupBy`, `flatten`
-- `@rtorcato/js-common/strings` → suggest `capitalize`, `kebabCase`, `camelCase`, `truncate`
-- `@rtorcato/js-common/validation` → suggest `isEmail`, `isUrl`, `isEmpty`, `isLength`
-- `@rtorcato/js-common/try` → suggest `attempt`, `trycatch` for error handling
-- `@rtorcato/js-common/objects` → suggest `pick`, `omit`, `merge`, `deepClone`
+- `@rtorcato/js-common/arrays` → suggest `unique`, `chunk`, `groupBy`, `flatten`, `compact`
+- `@rtorcato/js-common/strings` → suggest `capitalize`, `titleCase`, `kebabCase`, `camelCase`, `truncate`, `isBlank`
+- `@rtorcato/js-common/validation` → suggest `isEmail`, `isUrl`, `isString`, `isDefined`
+- `@rtorcato/js-common/try` → suggest `tryCatch`, `isSuccess` for error handling
+- `@rtorcato/js-common/objects` → suggest `pick`, `omit`, `deepMerge`, `deepClone`
+- `@rtorcato/js-common/numbers` → suggest `clamp`, `roundTo`, `sum`, `average`
+- `@rtorcato/js-common/currency` → suggest `formatPrice` for money formatting
+
+Never suggest a bare `@rtorcato/js-common` import: the root entry has no runtime
+code, so a root import resolves to nothing.
 
 ### Function Chaining Patterns
 ```typescript
 // Suggest chaining for array operations
-const result = users
-  .filter(isActive)
-  .map(u => pick(u, ['id', 'name']))
-  .reduce(groupBy('department'))
+const grouped = groupBy(
+  users.filter(isActive).map((u) => pick(u, ['id', 'name', 'department'])),
+  (u) => u.department
+)
 
 // Suggest error handling for async chains
-const data = await attempt(() =>
+const { data, error } = await tryCatch(() =>
   fetch(url)
-    .then(r => r.json())
+    .then((r) => r.json())
     .then(validateData)
 )
 ```
@@ -198,4 +192,4 @@ const data = await attempt(() =>
 ### TypeScript Integration
 - Always preserve generic types: `unique<User>(users)`
 - Suggest type guards: `if (isString(value)) { /* value is string */ }`
-- Use type inference: `const grouped = groupBy(items, 'category')` // infers grouping type
+- Use type inference: `const grouped = groupBy(items, (item) => item.category)` // infers grouping type

--- a/scripts/check-readme-exports.mjs
+++ b/scripts/check-readme-exports.mjs
@@ -7,7 +7,8 @@
  *  2. No export name is reachable from two different subpaths — the freeze's
  *     "every helper has exactly one home" rule.
  *  3. Every `import { … } from '@rtorcato/js-common/<module>'` sample anywhere in
- *     README.md or apps/docs/docs/** names something that module really exports.
+ *     README.md, apps/docs/docs/** or .github/skills/** names something that
+ *     module really exports.
  *
  *   node scripts/check-readme-exports.mjs --check   # exit 1 on drift (used by CI)
  */
@@ -109,22 +110,51 @@ for (const [name, subs] of homes) {
 const IMPORT_EXAMPLE =
 	/import\s+(?:type\s+)?\{([^}]+)\}\s*from\s*['"]@rtorcato\/js-common\/([\w-]+)['"]/g
 const docFiles = [join(root, 'README.md')]
-const docsDir = join(root, 'apps', 'docs', 'docs')
-if (existsSync(docsDir)) {
-	for (const name of readdirSync(docsDir, { recursive: true })) {
-		if (/\.mdx?$/.test(name)) docFiles.push(join(docsDir, name))
+// .github/skills/** is Copilot-facing: a wrong name there is taught to an
+// assistant writing code against this package, so it gets the same check.
+for (const dir of [join(root, 'apps', 'docs', 'docs'), join(root, '.github', 'skills')]) {
+	if (!existsSync(dir)) continue
+	for (const name of readdirSync(dir, { recursive: true })) {
+		if (/\.mdx?$/.test(name)) docFiles.push(join(dir, name))
 	}
 }
 
-// A migration guide has to quote the API it is migrating away from. A fenced
-// block containing `boundary-check: ignore` is skipped for that reason.
-const FENCE = /^```[\s\S]*?^```/gm
+/**
+ * Blank out every fenced block containing `boundary-check: ignore` — a migration
+ * guide has to quote the API it is migrating away from.
+ *
+ * Line-oriented on purpose: the regex this replaced (`/^```[\s\S]*?^```/gm`) had
+ * to rescan to EOF from every opener that never closed, which is polynomial on a
+ * file with many unclosed fences. Walking once is linear and lets an unclosed
+ * fence be handled deliberately — its lines are kept and still checked, rather
+ * than being silently paired with the *next* block's opener, which used to shift
+ * which block the ignore marker appeared to belong to.
+ */
+function stripIgnoredBlocks(text) {
+	const kept = []
+	let fence = null
+	for (const line of text.split('\n')) {
+		if (line.startsWith('```')) {
+			if (fence) {
+				fence.push(line)
+				if (!fence.some((l) => l.includes('boundary-check: ignore'))) kept.push(...fence)
+				fence = null
+			} else {
+				fence = [line]
+			}
+			continue
+		}
+		if (fence) fence.push(line)
+		else kept.push(line)
+	}
+	// Unclosed fence: not an opt-out, so keep it and check what is inside.
+	if (fence) kept.push(...fence)
+	return kept.join('\n')
+}
 
 for (const file of docFiles) {
 	const where = relative(root, file)
-	const text = readFileSync(file, 'utf8').replace(FENCE, (block) =>
-		block.includes('boundary-check: ignore') ? '' : block
-	)
+	const text = stripIgnoredBlocks(readFileSync(file, 'utf8'))
 	for (const m of text.matchAll(IMPORT_EXAMPLE)) {
 		const sub = m[2]
 		const available = exportsBySubpath.get(sub)


### PR DESCRIPTION
`.github/skills/*.md` is Copilot-facing, so every wrong export name in it was
being taught to an assistant writing code against this package. Issue #185
fixed this class of problem in README.md and apps/docs/docs/**; these three
files were outside its scope.

Closes #202
Closes #203

#203 — replace the `FENCE` regex in scripts/check-readme-exports.mjs
(`/^```[\s\S]*?^```/gm`) with a line-oriented scan. The lazy quantifier had to
rescan to EOF from every opener that never closed. The scan is linear, matches
how markdown actually parses, and handles an unclosed fence deliberately: its
lines are kept and still checked rather than being silently paired with the
next block's opener, which used to shift which block the `boundary-check:
ignore` marker appeared to belong to. The opt-out itself is unchanged.

#202 — done:

- Extended that checker to `.github/skills/**`. This is the part that stops
  the drift recurring; it flagged all 25 bad names below on its first run, and
  would have caught every one of them when they were written.
- Replaced the fabricated names with the real exports, verified against
  `src/`: `isEmpty`→`isBlank` (strings), `round`→`roundTo` (takes a precision
  argument), `formatCurrency`→`formatPrice` (currency), `hash`→`hashString`
  (crypto), `trycatch`→`tryCatch`, `getEnv`/`requireEnv`→`getENV`,
  `isUuid`→`isUUID` (uuid), `merge`→`deepMerge`, `diffDays`→`daysBetween`.
  `random`, `isLength`, `filterBy`, `encrypt` and `decrypt` have no equivalent,
  so those examples were rewritten around helpers that do exist.
- Corrected the call sites too, not just the names: `groupBy` takes a key
  function rather than a property name, `formatDate` takes no format string,
  and `tryCatch` returns `{ data, error }` rather than `{ success, data }`.
- Unmangled `advanced-patterns.md` line 169 — a single 3,156-character line of
  literal `\n` escapes that collapsed three sections into one unreadable line.

#202 — not done:

- Did not delete the three files. The issue asked whether they are still
  wanted now that `AGENTS.md` exists; that is the maintainer's call, and the
  checker makes keeping them cheap.

Two things found while verifying, both left for separate issues:

- `attempt` is not reachable from `@rtorcato/js-common/try`. It exists at
  `src/try/attempt.ts`, but `src/try/index.ts` only re-exports `./trycatch.js`,
  so the subpath ships `tryCatch`, `isSuccess` and the `Result` types alone.
  #202 lists `attempt` as real; the checker disagrees, and the checker is
  right. Examples now use `tryCatch`. Whether the export is missing by
  accident or by design is a source change, out of scope here.
- The skills files imported from the package root. #202 says to leave those
  alone because `package.json` has a `"."` export — but `src/index.ts` is
  `export {}`, and `AGENTS.md` rule 1 plus the tree-shaking guide both state
  that a root import "resolves to nothing". The specifier resolves; the named
  imports do not. They are now subpath imports, which also brings them under
  the checker. Revert that part if the intent was to keep them as-is.