### PR TITLE
feat(security)!: rename sanitizeString to stripScriptish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Import from `@rtorcato/js-common/<module>`.
 | promises | delay, to, withTimeout, all, allSettled, race |
 | random | randomInt, randomFloat, randomBool, randomElement, randomString |
 | regex | escapeRegExp, testRegex, matchAll, replaceAllRegex, splitByRegex |
-| security | sanitizeString, isStrongPassword, generateSecureToken |
+| security | stripScriptish, isStrongPassword, generateSecureToken |
 | sets | union, intersection, difference, isSubset, isSuperset, setToArray, arrayToSet |
 | sleep | sleep, sleepSync, sleepRandom, sleepWithAbort |
 | strings | titleCase, capitalize, camelCase, kebabCase, snakeCase, truncate, padStart, padEnd, replaceString, reverse, slugify, words, wordCount, pluralize, ordinalize, isBlank, mask, template |

--- a/MODULE-BOUNDARIES.md
+++ b/MODULE-BOUNDARIES.md
@@ -112,7 +112,7 @@ No behaviour change for anyone importing from the owner.
 | Name | Owner | Removed from | Note |
 |---|---|---|---|
 | `roundTo` | `./numbers` | `./currency` | byte-identical |
-| `sanitizeString` | `./security` | `./strings` | byte-identical; sanitising is a security concern |
+| `sanitizeString` | `./security` | `./strings` | byte-identical; sanitising is a security concern. Since renamed `stripScriptish` — see [#201](https://github.com/rtorcato/js-common/issues/201) |
 | `isBoolean` | `./validation` | `./boolean` | identical; belongs with the `is*` family. `./boolean` keeps the logic operators (`and`, `or`, `not`, `xor`, `toBoolean`) |
 | `escapeHtml` | `./html` | `./strings` | different implementations, same output |
 | `formatTime` | `./time` | `./formatting` | both local `HH:MM:SS` |

--- a/apps/docs/docs/guides/migration.md
+++ b/apps/docs/docs/guides/migration.md
@@ -39,7 +39,7 @@ Import from the owner; the other module no longer exports the name.
 |---|---|---|
 | `roundTo` | `numbers` | `currency` |
 | `randomString` | `random` | `strings` |
-| `sanitizeString` | `security` | `strings` |
+| `sanitizeString` | `security` | `strings` — and renamed, see below |
 | `escapeHtml`, `unescapeHtml` | `html` | `strings` |
 | `pluralize` | `strings` | `i18n` |
 | `formatNumber` | `i18n` | — (`formatting` removed) |
@@ -57,6 +57,41 @@ Three of these changed behaviour where the surviving copy was the stricter one:
 
 `html.unescapeHtml` also **adopted the `strings` implementation**, so it now
 decodes `&#x27;`, `&#x2F;` and `&nbsp;` as well.
+
+### `sanitizeString` is now `stripScriptish`
+
+```ts
+// boundary-check: ignore — quotes the pre-3.0 name on purpose
+- import { sanitizeString } from '@rtorcato/js-common/security'
+- sanitizeString(html)
++ import { stripScriptish } from '@rtorcato/js-common/security'
++ stripScriptish(html)
+```
+
+Same function, honest name. It removes `<script>` blocks and inline `on*=`
+handlers and nothing else — a blocklist over two shapes. It was never a
+sanitizer, and the old name invited people to use it as one without reading the
+caveat that has been in its docs the whole time.
+
+**If you were relying on it to make untrusted HTML safe, renaming the import is
+not the fix.** Escape with [`html.escapeHtml`](../modules/html.md), or run
+DOMPurify when the markup has to survive.
+
+Three behaviour changes came with the rename, all of them things the old
+regexes got wrong:
+
+- Unquoted handlers are now removed. `<img src=x onerror=alert(1)>` was
+  previously left intact, because the old pattern required matching quotes.
+- `</script >` now closes a block. The old pattern demanded `</script>` exactly,
+  so a space defeated it (CodeQL `js/bad-tag-filter`).
+- No stray space is left behind. `<div onclick="x()">` yields `<div>`, not
+  `<div >`. Update snapshot tests that captured the old output.
+
+Performance also changed by three orders of magnitude on hostile input:
+`'<script'.repeat(40_000)` took 9.8s and now takes ~2ms. The old
+implementation backtracked once per `<script` occurrence
+(CodeQL `js/polynomial-redos`), which was a denial-of-service vector for anyone
+passing it attacker-controlled strings.
 
 ### Renames
 

--- a/apps/docs/docs/guides/migration.md
+++ b/apps/docs/docs/guides/migration.md
@@ -82,6 +82,8 @@ regexes got wrong:
 
 - Unquoted handlers are now removed. `<img src=x onerror=alert(1)>` was
   previously left intact, because the old pattern required matching quotes.
+  So was `<img/onerror=alert(1)>`, where `/` separates the attribute instead
+  of a space.
 - `</script >` now closes a block. The old pattern demanded `</script>` exactly,
   so a space defeated it (CodeQL `js/bad-tag-filter`).
 - No stray space is left behind. `<div onclick="x()">` yields `<div>`, not

--- a/apps/docs/docs/modules/security.md
+++ b/apps/docs/docs/modules/security.md
@@ -3,7 +3,7 @@ title: Security
 description: Utilities exported from @rtorcato/js-common/security.
 ---
 
-A small set of security-adjacent helpers: password-strength checks, cryptographically secure tokens from `node:crypto`, and coarse string sanitisation. `generateSecureToken` uses `randomBytes` — the `Math.random` helpers in `random` are never an acceptable substitute here. `sanitizeString` strips only `<script>` blocks and inline `on*` handlers with regexes, so treat it as defence in depth: escape untrusted values with `html.escapeHtml`, or run a real sanitizer such as DOMPurify when markup must survive.
+A small set of security-adjacent helpers: password-strength checks, cryptographically secure tokens from `node:crypto`, and coarse script stripping. `generateSecureToken` uses `randomBytes` — the `Math.random` helpers in `random` are never an acceptable substitute here. `stripScriptish` (called `sanitizeString` before 3.0) removes only `<script>` blocks and inline `on*` handlers, so treat it as defence in depth: escape untrusted values with `html.escapeHtml`, or run a real sanitizer such as DOMPurify when markup must survive. It was renamed precisely because the old name promised a guarantee it never delivered.
 
 ## Example
 
@@ -22,7 +22,7 @@ const token = generateSecureToken(32) // 64 hex characters
 ## Import
 
 ```ts
-import { generateSecureToken, isStrongPassword, sanitizeString } from '@rtorcato/js-common/security'
+import { generateSecureToken, isStrongPassword, stripScriptish } from '@rtorcato/js-common/security'
 ```
 
 ## Exports
@@ -31,7 +31,7 @@ import { generateSecureToken, isStrongPassword, sanitizeString } from '@rtorcato
 | --- | --- |
 | `generateSecureToken` | Generates a cryptographically secure random token (hex string). |
 | `isStrongPassword` | Checks if a password is strong (min 8 chars, upper, lower, number, special char). |
-| `sanitizeString` | Sanitizes a string by removing script tags and event handlers. |
+| `stripScriptish` | Removes `<script>` blocks and inline `on*=` event-handler attributes from a string. |
 
 <!-- /generated:exports -->
 

--- a/skills/js-common/SKILL.md
+++ b/skills/js-common/SKILL.md
@@ -92,7 +92,7 @@ Import from `@rtorcato/js-common/<module>`.
 | promises | delay, to, withTimeout, all, allSettled, race |
 | random | randomInt, randomFloat, randomBool, randomElement, randomString |
 | regex | escapeRegExp, testRegex, matchAll, replaceAllRegex, splitByRegex |
-| security | sanitizeString, isStrongPassword, generateSecureToken |
+| security | stripScriptish, isStrongPassword, generateSecureToken |
 | sets | union, intersection, difference, isSubset, isSuperset, setToArray, arrayToSet |
 | sleep | sleep, sleepSync, sleepRandom, sleepWithAbort |
 | strings | titleCase, capitalize, camelCase, kebabCase, snakeCase, truncate, padStart, padEnd, replaceString, reverse, slugify, words, wordCount, pluralize, ordinalize, isBlank, mask, template |

--- a/src/security/index.test.ts
+++ b/src/security/index.test.ts
@@ -16,6 +16,10 @@ describe('security module', () => {
 		expect(stripScriptish('<script type="text/javascript">bad()</script>')).toBe('')
 		// An unquoted handler value needs no quotes to fire.
 		expect(stripScriptish('<img src=x onerror=alert(1)>')).toBe('<img src=x>')
+		// …and no space either: `/` separates attributes just as well.
+		expect(stripScriptish('<img/onerror=alert(1)>')).toBe('<img>')
+		// The `/` arm must not eat a legitimate slash in an attribute value.
+		expect(stripScriptish('<img src=/foo.png>')).toBe('<img src=/foo.png>')
 		// Single quotes.
 		expect(stripScriptish("<div onclick='evil()'>hi</div>")).toBe('<div>hi</div>')
 		// `<scriptural>` is not a script tag — `\b` keeps it.

--- a/src/security/index.test.ts
+++ b/src/security/index.test.ts
@@ -1,12 +1,48 @@
 import { describe, expect, it } from 'vitest'
-import { generateSecureToken, isStrongPassword, sanitizeString } from './index'
+import { generateSecureToken, isStrongPassword, stripScriptish } from './index'
 
 describe('security module', () => {
-	it('sanitizeString removes script tags and event handlers', () => {
-		expect(sanitizeString('<script>alert(1)</script>hello')).toBe('hello')
-		expect(sanitizeString('<div onclick="evil()">hi</div>')).toBe('<div >hi</div>')
-		expect(sanitizeString('<a href="#" onmouseover="bad()">link</a>')).toBe('<a href="#" >link</a>')
-		expect(sanitizeString('plain')).toBe('plain')
+	it('stripScriptish removes script tags and event handlers', () => {
+		expect(stripScriptish('<script>alert(1)</script>hello')).toBe('hello')
+		expect(stripScriptish('<div onclick="evil()">hi</div>')).toBe('<div>hi</div>')
+		expect(stripScriptish('<a href="#" onmouseover="bad()">link</a>')).toBe('<a href="#">link</a>')
+		expect(stripScriptish('plain')).toBe('plain')
+	})
+
+	it('stripScriptish handles what the old regexes missed', () => {
+		// js/bad-tag-filter: `</script >` is a valid end tag.
+		expect(stripScriptish('<script>bad()</script >tail')).toBe('tail')
+		// Attributes on the opening tag.
+		expect(stripScriptish('<script type="text/javascript">bad()</script>')).toBe('')
+		// An unquoted handler value needs no quotes to fire.
+		expect(stripScriptish('<img src=x onerror=alert(1)>')).toBe('<img src=x>')
+		// Single quotes.
+		expect(stripScriptish("<div onclick='evil()'>hi</div>")).toBe('<div>hi</div>')
+		// `<scriptural>` is not a script tag — `\b` keeps it.
+		expect(stripScriptish('<scriptural>text</scriptural>')).toBe('<scriptural>text</scriptural>')
+	})
+
+	it('stripScriptish is bypassable, as documented', () => {
+		// The executable record of the ceiling. A blocklist over two shapes leaves
+		// everything it does not name, so this is XSS that survives the function
+		// untouched. Asserted here so the weakness stays visible in the repo even
+		// though CodeQL no longer reports it against an index scan.
+		expect(stripScriptish('<a href="javascript:alert(1)">x</a>')).toBe(
+			'<a href="javascript:alert(1)">x</a>'
+		)
+		// Nesting the pattern inside itself also defeats the single pass.
+		expect(stripScriptish('<scr<script>ipt>alert(1)</scr</script>ipt>')).toBe('<script>')
+	})
+
+	it('stripScriptish stays linear on the CodeQL blowup inputs', () => {
+		// js/polynomial-redos alert #11: '<script' repeated, and '<script>' then
+		// many '>'. Quadratic backtracking made the first of these take 9.8s; the
+		// index scan does both in ~2ms. Generous bound — this catches a return to
+		// quadratic, not a slowdown.
+		const start = performance.now()
+		stripScriptish('<script'.repeat(40_000))
+		stripScriptish(`<script>${'>'.repeat(40_000)}`)
+		expect(performance.now() - start).toBeLessThan(1_000)
 	})
 
 	it('isStrongPassword validates strong passwords', () => {

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -28,7 +28,16 @@ export function stripScriptish(str: string): string {
 	// the old `(['"]).*?\1` could not see — `onerror=alert(1)` needs no quotes to
 	// fire, and `<img/onerror=…>` needs no space either. The leading separator is
 	// consumed so removal leaves no stray character.
-	return removeScriptBlocks(str).replace(/[\s/]on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi, '')
+	//
+	// Apply repeatedly until stable to avoid incomplete multi-character
+	// sanitization where one removal can expose a new `on*=` sequence.
+	let sanitized = removeScriptBlocks(str)
+	let previous: string
+	do {
+		previous = sanitized
+		sanitized = sanitized.replace(/[\s/]on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi, '')
+	} while (sanitized !== previous)
+	return sanitized
 }
 
 /**

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -26,8 +26,9 @@ export function stripScriptish(str: string): string {
 	// The handler pass stays a regex: the alternation is over bounded character
 	// classes, so there is nothing to backtrack into. The bare-value arm is what
 	// the old `(['"]).*?\1` could not see — `onerror=alert(1)` needs no quotes to
-	// fire. Leading `\s` is consumed so removal leaves no stray space.
-	return removeScriptBlocks(str).replace(/\son\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi, '')
+	// fire, and `<img/onerror=…>` needs no space either. The leading separator is
+	// consumed so removal leaves no stray character.
+	return removeScriptBlocks(str).replace(/[\s/]on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi, '')
 }
 
 /**

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -1,22 +1,79 @@
 import { randomBytes } from 'node:crypto'
 
 /**
- * Sanitizes a string by removing script tags and event handlers.
+ * Removes `<script>` blocks and inline `on*=` event-handler attributes from a string.
+ *
+ * **Not a sanitizer, and deliberately not named like one.** It is a blocklist over
+ * two shapes, so anything it does not name survives, and a single pass can be
+ * defeated by nesting the pattern inside itself. Use it as defence in depth on
+ * markup you already trust. For untrusted input, escape with `html.escapeHtml`,
+ * or run a real sanitizer such as DOMPurify when the markup must survive.
  *
  * @example
  * ```typescript
- * sanitizeString('<p onclick="steal()">hi</p><script>bad()</script>')
- * // '<p >hi</p>'
+ * stripScriptish('<p onclick="steal()">hi</p><script>bad()</script>')
+ * // '<p>hi</p>'
  *
- * // Blocklist-based, so it is bypassable — not a substitute for a real
- * // sanitizer such as DOMPurify when rendering untrusted HTML.
+ * // Bypassable by construction — this is XSS it does not name, so it survives:
+ * stripScriptish('<a href="javascript:alert(1)">x</a>')
+ * // '<a href="javascript:alert(1)">x</a>'
  * ```
  *
- * @param str The string to sanitize.
- * @returns The sanitized string.
+ * @param str The string to strip.
+ * @returns The string with script blocks and inline handlers removed.
  */
-export function sanitizeString(str: string): string {
-	return str.replace(/<script.*?>.*?<\/script>/gi, '').replace(/on\w+\s*=\s*(['"]).*?\1/gi, '')
+export function stripScriptish(str: string): string {
+	// The handler pass stays a regex: the alternation is over bounded character
+	// classes, so there is nothing to backtrack into. The bare-value arm is what
+	// the old `(['"]).*?\1` could not see — `onerror=alert(1)` needs no quotes to
+	// fire. Leading `\s` is consumed so removal leaves no stray space.
+	return removeScriptBlocks(str).replace(/\son\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi, '')
+}
+
+/**
+ * One left-to-right pass removing `<script …>…</script …>` blocks.
+ *
+ * Deliberately not a regex. Every lazy variant of this pattern rescans to the end
+ * of the input once per `<script` occurrence, so `'<script'.repeat(n)` costs
+ * O(n²) — 2.5s at n=20_000, which is CodeQL `js/polynomial-redos` alert #11.
+ * Each `indexOf` below resumes from a monotonically increasing offset, so the
+ * whole pass is linear.
+ *
+ * Known ceiling: `</scriptural>` is accepted as a closing tag. Rejecting it means
+ * resuming the closer search mid-scan, which is more machinery than an
+ * intentionally coarse stripper is worth.
+ */
+function removeScriptBlocks(str: string): string {
+	const lower = str.toLowerCase()
+	let out = ''
+	let from = 0
+	let at = 0
+
+	for (;;) {
+		const open = lower.indexOf('<script', at)
+		if (open === -1) break
+
+		// `<scriptural>` is not a script tag. Skip past it rather than giving up.
+		const next = lower[open + 7]
+		if (next !== undefined && next !== '>' && next !== '/' && !/\s/.test(next)) {
+			at = open + 7
+			continue
+		}
+
+		const openEnd = lower.indexOf('>', open)
+		if (openEnd === -1) break
+		const close = lower.indexOf('</script', openEnd)
+		if (close === -1) break
+		// Matches `</script >` too, which the old pattern missed (js/bad-tag-filter).
+		const closeEnd = lower.indexOf('>', close)
+		if (closeEnd === -1) break
+
+		out += str.slice(from, open)
+		from = closeEnd + 1
+		at = from
+	}
+
+	return out + str.slice(from)
 }
 
 /**

--- a/src/strings/README.md
+++ b/src/strings/README.md
@@ -161,13 +161,13 @@ replaceString('hello world world', 'world', 'there') // 'hello there there'
 ### HTML Handling
 
 HTML escaping, unescaping and tag stripping live in
-[`html`](../html); string sanitizing lives in [`security`](../security).
+[`html`](../html); coarse script stripping lives in [`security`](../security).
 Random strings live in [`random`](../random).
 
 ```typescript
 import { escapeHtml, stripHtmlTags, unescapeHtml } from '@rtorcato/js-common/html'
 import { randomString } from '@rtorcato/js-common/random'
-import { sanitizeString } from '@rtorcato/js-common/security'
+import { stripScriptish } from '@rtorcato/js-common/security'
 ```
 
 ### Text Analysis


### PR DESCRIPTION
Closes #201. Takes option 2 — rename — plus the unambiguous ReDoS fix.

## The name was the defect

`sanitizeString` is a blocklist over two shapes: `<script>` blocks and inline `on*=` handlers. Its JSDoc has said "bypassable — not a substitute for a real sanitizer such as DOMPurify" the whole time, and that caveat is honest. The problem #201 identifies is that a function called `sanitizeString`, shipped from a published package, gets used as a sanitizer by people who never read it.

3.0.0 is queued and unreleased, so this rides along at no extra semver cost. That window closes on publish.

## The ReDoS is fixed properly

CodeQL `js/polynomial-redos`, alert #11 — the one part of #201 nobody disputes:

| input | before | after |
|---|---|---|
| `'<script'.repeat(40_000)` | **9,795ms** | 2ms |
| `'<script>' + '>'.repeat(40_000)` | 0ms | 0ms |

The old pattern rescanned to end-of-input once per `<script` occurrence. I first tried keeping it a regex with the usual `[^>]*` fix, and measured it: still quadratic, 2.5s at n=20,000. Every lazy variant is, because the closer search restarts at each opener. So the script pass is now a single left-to-right `indexOf` scan where every offset advances monotonically. The handler pass stays a regex — its alternation is over bounded classes with nothing to backtrack into.

## Three real bypasses closed

Not alert-silencing; these were wrong:

- **Unquoted handlers.** `<img src=x onerror=alert(1)>` passed through untouched, because `(['"]).*?\1` required matching quotes. Now removed.
- **`</script >`.** The old pattern demanded `</script>` exactly, so one space defeated it. This is CodeQL `js/bad-tag-filter` (alert #1), now genuinely fixed rather than dismissed.
- **Stray space.** `<div onclick="x()">hi</div>` gave `<div >hi</div>`. Now `<div>hi</div>`.

`<scriptural>` is still not treated as a script tag — covered by a test, since the index scan had to re-earn what `\b` gave the regex for free.

## The part #201 explicitly warned about

> Do not repeat that pattern here by accident: rewriting `sanitizeString`'s regexes would silence alerts #4/#5/#1 while leaving it exactly as bypassable.

An index scan **does** stop CodeQL reporting `js/incomplete-multi-character-sanitization` (alerts #4, #5) — it no longer recognises the code as a tag filter. That is unavoidable if the ReDoS is to be fixed at all, since the fix is precisely "stop being a regex".

So it is done deliberately, not by accident, and the weakness is recorded in three places that are harder to silence than a CodeQL alert nobody reads:

1. **The name.** `stripScriptish` does not promise safety.
2. **The JSDoc**, which now leads with "Not a sanitizer, and deliberately not named like one" and shows a surviving XSS payload.
3. **A test that asserts the bypass** — `stripScriptish('<a href="javascript:alert(1)">x</a>')` must return its input unchanged. It fails if someone later "fixes" the function into looking safe without making it safe.

That last one is the thing #197's `stripHtmlTags` rewrite lacked. Worth adding there too, separately.

Alerts #4 and #5 should be dismissed as won't-fix once this lands — say the word and I'll do it, or leave them to age out when the code they point at no longer exists.

## Migration

`apps/docs/docs/guides/migration.md` gets a section covering the rename, the three behaviour changes, and an explicit warning that swapping the import is **not** a security fix. Also updated: `AGENTS.md`, `skills/js-common/SKILL.md`, `MODULE-BOUNDARIES.md`, `src/strings/README.md`, and the generated exports block in `modules/security.md` via `pnpm docs:generate`.

## Verification

- `pnpm exec vitest run` — 411 passed, 54 files. Security suite goes from 1 test to 5, covering both regressions and the documented ceiling.
- `pnpm typecheck`, `pnpm check`, `node scripts/check-readme-exports.mjs` — all clean.
- Watch CodeQL on this PR. If the rename re-reports #4/#5 as *new* alerts at the new location, the `code-scanning-main` ruleset may block the merge; that needs a dismissal rather than a code change.

**Merging this publishes 3.0.0**, including everything else already queued on `main`.