### PR TITLE
fix(cli): stop advertising six commands that were never registered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ pnpm run build-dev       # development build (esbuild + tsc declarations)
 pnpm run build-prod      # production build
 pnpm run build-cli       # CLI build (separate TypeScript compilation + shebang injection)
 pnpm test                # vitest
-pnpm coverage            # vitest with Istanbul coverage
+pnpm coverage            # vitest with V8 coverage (@vitest/coverage-v8)
 pnpm typecheck           # tsc --noEmit
 pnpm lint                # biome lint (read-only)
 pnpm format              # biome format (write)
@@ -43,5 +43,7 @@ Husky runs `pnpm typecheck` and `pnpm check` on every commit. This can be slow �
 
 ## Notes
 
-- The CLI (`src/cli/`) is built with a separate script and has its own `tsconfig`. Do not include it in the main library build.
-- Required env vars for CI releases: `GITHUB_TOKEN`, `NPM_TOKEN` (GitHub Actions), `GITLAB_TOKEN` (GitLab CI).
+- The CLI (`src/cli/`) is built by `build-cli`, which runs `tsc` with `--ignoreConfig` and every flag inline — there is no CLI `tsconfig`, only `tsconfig.json` and `tsconfig.build.json`. Do not include the CLI in the main library build.
+- The CLI is a shop window, not a port of the library. `src/cli/catalog.ts` may only advertise verbs that `src/cli/cli.ts` actually registers; `catalog.test.ts` enforces both that and the `exportName`s being real.
+- Required env vars for CI releases: `GITHUB_TOKEN`, `NPM_TOKEN` (GitHub Actions).
+- Releases are gated on the `release` GitHub environment and need a manual approval — a merge to `main` leaves the pipeline `waiting`, it does not publish on its own.

--- a/CLI.md
+++ b/CLI.md
@@ -77,10 +77,10 @@ This command provides:
 # Get today's date (YYYY-MM-DD)
 js-common date today
 
-# Get current timestamp
+# Get current timestamp (epoch milliseconds)
 js-common date now
 js-common date now --iso     # ISO format
-js-common date now --time    # Time only (HH:MM:SS)
+js-common date now --time    # Time, e.g. 14:32:07 GMT+0000 (Coordinated Universal Time)
 
 # Calculate days between dates
 js-common date between 2025-01-01 2025-12-31
@@ -96,10 +96,10 @@ js-common math sum 1 2 3 4 5
 js-common math avg 10 20 30 40 50
 
 # Generate random number
-js-common math random --min 1 --max 100
+js-common math random 1 100
 
 # Round number to decimal places
-js-common math round 3.14159 --decimals 2
+js-common math round 3.14159 2
 
 # Clamp number between min/max
 js-common math clamp 150 0 100
@@ -113,36 +113,6 @@ js-common text capitalize "hello world"
 
 # Convert to title case
 js-common text title "hello world from javascript"
-
-# Pad with leading zeros
-js-common text pad 5 --length 3
-```
-
-### File Operations
-
-```bash
-# Check if file exists (exit code 0 = exists, 1 = doesn't exist)
-js-common file exists package.json
-
-# Get file extension
-js-common file ext myfile.txt
-```
-
-### Security Utilities
-
-```bash
-# Check password strength (exit code 0 = strong, 1 = weak)
-js-common security password "MyStr0ng!Pass"
-
-# Generate secure random token
-js-common security token --length 32
-```
-
-### Validation
-
-```bash
-# Validate URL (exit code 0 = valid, 1 = invalid)
-js-common validate url "https://example.com"
 ```
 
 ### System Information
@@ -154,28 +124,13 @@ js-common system pid
 # Get process uptime in seconds
 js-common system uptime
 
-# Check if running in CI environment
-js-common system ci
-
 # Get Node.js major version
 js-common system node-version
 ```
 
-## Exit Codes
-
-Many validation commands use exit codes to indicate success/failure:
-- `0`: Success/Valid/True
-- `1`: Failure/Invalid/False
-
-This makes them useful in shell scripts:
-
-```bash
-if js-common validate url "https://example.com"; then
-    echo "Valid URL"
-else
-    echo "Invalid URL"
-fi
-```
+That is the whole command surface. The CLI is a shop window for the library, not a
+port of it — most of the package (`file`, `security`, `validation`, and the rest of
+the 44 modules) is import-only. Use `js-common add` to get the import statement.
 
 ## 💡 Developer Integration Examples
 
@@ -189,12 +144,14 @@ npx @rtorcato/js-common add
 # Interactive workflow:
 # 1. Select category (e.g., "🔢 Mathematical")
 # 2. Choose functions (e.g., sum, avg, random)
-# 3. Get generated import statement:
-#    import { sum, avg, random } from '@rtorcato/js-common/numbers'
+# 3. Get generated import statements — note these are the *export* names, which
+#    differ from the CLI verbs, and one import per module the category spans:
+#    import { sum, average } from '@rtorcato/js-common/numbers'
+#    import { randomInt } from '@rtorcato/js-common/random'
 # 4. See usage examples:
-#    const total = sum([1, 2, 3, 4, 5]); // 15
-#    const average = avg([10, 20, 30]); // 20
-#    const num = randomBetween(1, 100); // 42
+#    const total = sum([1, 2, 3, 4, 5]) // 15
+#    const mean = average([10, 20, 30]) // 20
+#    const num = randomInt(1, 100) // 42
 ```
 
 ### CLI Usage Examples
@@ -217,10 +174,6 @@ npx @rtorcato/js-common system pid         # 12345
 
 ```bash
 #!/bin/bash
-
-# Generate a secure token for API keys
-API_KEY=$(js-common security token --length 16)
-echo "Generated API Key: $API_KEY"
 
 # Calculate project statistics
 TOTAL_FILES=$(find . -name "*.js" | wc -l)

--- a/MODULE-BOUNDARIES.md
+++ b/MODULE-BOUNDARIES.md
@@ -112,7 +112,7 @@ No behaviour change for anyone importing from the owner.
 | Name | Owner | Removed from | Note |
 |---|---|---|---|
 | `roundTo` | `./numbers` | `./currency` | byte-identical |
-| `sanitizeString` | `./security` | `./strings` | byte-identical; sanitising is a security concern. Since renamed `stripScriptish` — see [#201](https://github.com/rtorcato/js-common/issues/201) |
+| `stripScriptish` | `./security` | `./strings` | byte-identical; sanitising is a security concern. Called `sanitizeString` before 3.0 — renamed because the old name promised a guarantee it never delivered, see [#201](https://github.com/rtorcato/js-common/issues/201) |
 | `isBoolean` | `./validation` | `./boolean` | identical; belongs with the `is*` family. `./boolean` keeps the logic operators (`and`, `or`, `not`, `xor`, `toBoolean`) |
 | `escapeHtml` | `./html` | `./strings` | different implementations, same output |
 | `formatTime` | `./time` | `./formatting` | both local `HH:MM:SS` |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npx skills add https://github.com/rtorcato/js-common --skill js-common
 
 ## Migrating
 
-**2.x → 3.x** — every helper now has exactly one home. `./formatting` and `./math` are gone, and where two modules shipped the same name the loser was deleted rather than aliased, so you get a build error naming the fix. The full before/after map is in the [migration guide](https://rtorcato.github.io/js-common/docs/guides/migration); the reasoning is in [MODULE-BOUNDARIES.md](MODULE-BOUNDARIES.md).
+**2.x → 3.x** — every helper now has exactly one home. `./formatting` and `./math` are gone, and where two modules shipped the same name the loser was deleted rather than aliased, so you get a build error naming the fix. One helper was also renamed rather than moved: `sanitizeString` is now `stripScriptish`, because the old name promised sanitising it never did — it removes `<script>` blocks and inline `on*` handlers and nothing else. The full before/after map is in the [migration guide](https://rtorcato.github.io/js-common/docs/guides/migration); the reasoning is in [MODULE-BOUNDARIES.md](MODULE-BOUNDARIES.md).
 
 **1.x → 2.x** — the only breaking change in 2.0 is a rename in the `errors` module:
 
@@ -252,7 +252,7 @@ pnpm run benchmark
 The full documentation site lives in [`apps/docs`](./apps/docs) and is built with [Docusaurus](https://docusaurus.io/). It auto-deploys to GitHub Pages on every push to `main` that touches `apps/docs/**`.
 
 ```bash
-# Run the docs locally (http://localhost:4321/js-common)
+# Run the docs locally (http://localhost:3000/js-common/)
 pnpm --filter @rtorcato/js-common-docs dev
 
 # Build the static site

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,12 @@ We actively support the following versions of `@rtorcato/js-common`:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.x.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 3.x.x   | :white_check_mark: |
+| < 3.0   | :x:                |
+
+Only the latest major gets fixes. 3.0 moved every helper to exactly one module and
+renamed `sanitizeString` to `stripScriptish` — see [MODULE-BOUNDARIES.md](MODULE-BOUNDARIES.md)
+and the [migration guide](https://rtorcato.github.io/js-common/docs/guides/migration).
 
 ## Reporting a Vulnerability
 
@@ -36,19 +40,25 @@ We take security seriously. If you discover a security vulnerability, please rep
 
 This library follows security best practices:
 
-- ✅ **Minimal Runtime Dependencies**: Library utilities depend on a small, audited set (`date-fns`, `luxon`, `pino`, `uuid`, `short-uuid`, `zod`). CLI-only packages (`chalk`, `commander`, `inquirer`, `figlet`, …) are isolated to the `cli` subpath.
+- ✅ **Minimal Runtime Dependencies**: Library utilities depend on a small, audited set (`date-fns`, `date-fns-tz`, `luxon`, `pino`, `short-uuid`, `uuid`, `zod`). The CLI-only packages (`@inquirer/prompts`, `chalk`, `chalk-animation`, `commander`, `figlet`, `gradient-string`) are `optionalDependencies` used by the `js-common` binary, not by any importable subpath — there is no `./cli` export.
 - ✅ **Type Safety**: Full TypeScript support prevents many runtime errors
-- ✅ **Secure Defaults**: Crypto functions use strong algorithms (SHA-256, etc.)
-- ✅ **Input Validation**: Validation utilities help prevent injection attacks
+- ✅ **Secure Defaults**: `generateSecureToken` uses `randomBytes` from `node:crypto`. The `Math.random`-based helpers in `random` are never an acceptable substitute for it.
 - ✅ **Automated Updates**: Dependabot keeps dependencies current
 - ✅ **CI Security**: GitHub Actions with security scanning
 
 ### Known Security Considerations
 
-1. **Crypto Module**: Uses Node.js built-in crypto - ensure Node.js is up-to-date
-2. **Environment Variables**: Never commit secrets to version control
-3. **Input Validation**: Always validate user input before processing
-4. **CLI Tool**: Be cautious when running CLI commands with user input
+1. **`stripScriptish` is not a sanitizer**: it strips `<script>` blocks and inline
+   `on*` handlers, and nothing else. A blocklist over two shapes leaves everything it
+   does not name — `<a href="javascript:...">` survives it untouched. Treat it as
+   defence in depth: escape untrusted values with `html.escapeHtml`, or run a real
+   sanitizer such as DOMPurify when markup has to survive. It was renamed from
+   `sanitizeString` in 3.0 precisely because the old name promised a guarantee it
+   never delivered; `src/security/index.test.ts` asserts the bypasses so they stay visible.
+2. **Crypto Module**: Uses Node.js built-in crypto - ensure Node.js is up-to-date
+3. **Environment Variables**: Never commit secrets to version control
+4. **Input Validation**: Always validate user input before processing
+5. **CLI Tool**: Be cautious when running CLI commands with user input
 
 ### Security Resources
 

--- a/src/cli/catalog.test.ts
+++ b/src/cli/catalog.test.ts
@@ -1,8 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { functionCategories } from './catalog.js'
 
 const entries = Object.entries(functionCategories).flatMap(([category, { functions }]) =>
 	functions.map((func) => ({ category, ...func }))
+)
+
+// `cli.ts` calls `program.parse()` at module scope, so importing it would run the
+// CLI. Scan the source text instead — the same trick `scripts/check-readme-exports.mjs`
+// uses. `.command('x')` covers both `program.command(…)` and `<group>Cmd.command(…)`.
+const cliSource = readFileSync(fileURLToPath(new URL('./cli.ts', import.meta.url)), 'utf8')
+const registered = new Set(
+	Array.from(cliSource.matchAll(/\.command\('([^']+)'\)/g), (match) => match[1])
 )
 
 describe('cli function catalog', () => {
@@ -14,4 +24,16 @@ describe('cli function catalog', () => {
 			expect(Object.keys(mod)).toContain(exportName)
 		}
 	)
+
+	// The catalog is what `list`, `interactive` and `add` advertise. Anything in it
+	// that `cli.ts` never registers is a command the CLI offers and then fails to run.
+	it.each(entries)('js-common $category $name is a registered command', ({ name }) => {
+		expect(registered).toContain(name)
+	})
+
+	it('every category is a registered command group', () => {
+		for (const category of Object.keys(functionCategories)) {
+			expect(registered).toContain(category)
+		}
+	})
 })

--- a/src/cli/catalog.ts
+++ b/src/cli/catalog.ts
@@ -10,8 +10,12 @@
 // 'system') while the library groups by module — 'math' spans `numbers` and
 // `random`, 'system' spans `process` and `node`.
 //
-// `src/cli/catalog.test.ts` asserts every `exportName` really is exported by
-// `src/<subpath>/index.ts`, so this cannot drift back into fiction.
+// `src/cli/catalog.test.ts` asserts both halves, so this cannot drift back into
+// fiction: every `exportName` really is exported by `src/<subpath>/index.ts`,
+// and every `name` really is a command registered in `src/cli/cli.ts`. The
+// second check exists because it wasn't there — `file`, `security`, `validate`,
+// `text pad` and `system ci` were advertised here for long enough that `list`
+// printed commands that errored when run.
 export const functionCategories = {
 	date: {
 		name: '📅 Date & Time',
@@ -96,63 +100,6 @@ export const functionCategories = {
 				subpath: 'strings',
 				example: `const heading = titleCase('hello world') // 'Hello World'`,
 			},
-			{
-				name: 'pad',
-				description: 'Pad with leading zeros',
-				exportName: 'padStart',
-				subpath: 'strings',
-				example: `const padded = padStart('42', 5, '0') // '00042'`,
-			},
-		],
-	},
-	file: {
-		name: '📁 File Operations',
-		functions: [
-			{
-				name: 'exists',
-				description: 'Check if file exists',
-				exportName: 'fileExists',
-				subpath: 'file',
-				example: `const exists = await fileExists('package.json') // true`,
-			},
-			{
-				name: 'ext',
-				description: 'Get file extension',
-				exportName: 'getFileExtension',
-				subpath: 'file',
-				example: `const extension = getFileExtension('file.txt') // '.txt'`,
-			},
-		],
-	},
-	security: {
-		name: '🔒 Security',
-		functions: [
-			{
-				name: 'password',
-				description: 'Check password strength',
-				exportName: 'isStrongPassword',
-				subpath: 'security',
-				example: `const isStrong = isStrongPassword('MyPass123!') // true`,
-			},
-			{
-				name: 'token',
-				description: 'Generate secure token',
-				exportName: 'generateSecureToken',
-				subpath: 'security',
-				example: `const token = generateSecureToken(32) // 64 hex chars`,
-			},
-		],
-	},
-	validate: {
-		name: '✅ Validation',
-		functions: [
-			{
-				name: 'url',
-				description: 'Validate URL format',
-				exportName: 'isUrl',
-				subpath: 'validation',
-				example: `const isValid = isUrl('https://example.com') // true`,
-			},
 		],
 	},
 	system: {
@@ -171,13 +118,6 @@ export const functionCategories = {
 				exportName: 'getProcessUptime',
 				subpath: 'process',
 				example: `const uptime = getProcessUptime() // 123.45`,
-			},
-			{
-				name: 'ci',
-				description: 'Check CI environment',
-				exportName: 'isCI',
-				subpath: 'process',
-				example: `const inCi = isCI() // false`,
 			},
 			{
 				name: 'node-version',


### PR DESCRIPTION
Clearing the doc and CLI drift so **3.0.0 publishes accurate**. The release pipeline for #209 has been sitting in `waiting` on the `release` environment gate since Aug 12 — npm `latest` is still 2.8.2 while README and MODULE-BOUNDARIES already describe 3.0 as shipped. This lands first, then the gate gets approved.

## The bug

`src/cli/catalog.ts` is what `list`, `--list`, `interactive` and `add` print. It advertised six verbs that `src/cli/cli.ts` never registers, so `js-common list` printed commands that error when you run them:

| Advertised | Registered? |
|---|---|
| `file exists`, `file ext` | no `file` group at all |
| `security password`, `security token` | no `security` group at all |
| `validate url` | no `validate` group at all |
| `text pad` | no |
| `system ci` | no |

`catalog.test.ts` asserted every `exportName` really is exported by its module, but never that the verb is registered — exactly the half that would have caught this. **Both halves are now asserted**, so it can't drift back. Confirmed the new guard bites by temporarily re-adding `system ci`: `× js-common 'system' 'ci' is a registered command`.

Phantoms are **deleted**, not implemented. Accepted cost: `js-common add` loses discovery for `fileExists`, `getFileExtension`, `isStrongPassword`, `generateSecureToken`, `isUrl`, `isCI` and `padStart`. Those exports still ship — they're just no longer CLI-advertised. The CLI is a shop window for the library, not a port of it.

## Docs corrected alongside

Every item below was verified against source, not assumed:

- **CLI.md** — documented all six phantoms, plus an `## Exit Codes` section that only ever cited the three phantom groups. Also `math random --min/--max` and `math round --decimals` (both are actually positional), `date now --time` output (`toTimeString()`, not bare `HH:MM:SS`), a `security token` call in the shell-script example, and an `add` walkthrough showing `avg` and `randomBetween` — imports that don't exist. b8d572d changed `add` to print real export names grouped by subpath; CLI.md was never updated.
- **SECURITY.md** — supported-versions table listed only `1.x.x` ✅, i.e. the one version nobody runs. Named `inquirer` (it's `@inquirer/prompts`), omitted `date-fns-tz`, and claimed CLI deps are "isolated to the `cli` subpath" — there is no `./cli` export; the CLI ships via `bin`. Adds `stripScriptish`'s documented ceiling to Known Security Considerations, where it belongs.
- **README.md** — the 2.x → 3.x migration note covered the `./formatting` and `./math` removals but never mentioned `sanitizeString` → `stripScriptish`; the name appeared nowhere in the README. Docs port 4321 (Astro's default) → 3000 (Docusaurus, `baseUrl: /js-common/`).
- **CLAUDE.md** — claimed Istanbul coverage (dep is `@vitest/coverage-v8`), a CLI `tsconfig` that doesn't exist (`build-cli` passes `--ignoreConfig` with flags inline), and `GITLAB_TOKEN` as a release env var though there's no GitLab CI. Also records the release approval gate, which is what let 3.0.0 stall unnoticed.
- **MODULE-BOUNDARIES.md** — rekeys the row on `stripScriptish` instead of the old name.

Not touched: `apps/docs/docs/api/security.md` still says `sanitizeString()`, but `apps/docs/.gitignore` ignores `docs/api/` — it's a stale local TypeDoc artifact that regenerates on build.

## Verification

```
pnpm typecheck   clean
pnpm check       153 files, no fixes applied
pnpm test        54 files, 418 tests passed
node scripts/check-readme-exports.mjs --check
                 44 modules, 267 export names, 102 import samples resolve
npx tsx src/cli/cli.ts --list
                 only registered commands now print
```