### PR TITLE
chore(deps): bump @rtorcato/repo-tooling to 3.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "@biomejs/biome": "^2.5.0",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
-    "@rtorcato/repo-tooling": "^3.9.1",
+    "@rtorcato/repo-tooling": "^3.11.0",
     "@semantic-release/changelog": "^7.0.0",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^11.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^21.2.0
         version: 21.2.0
       '@rtorcato/repo-tooling':
-        specifier: ^3.9.1
-        version: 3.9.1(30d8862d0d43ceafc31e73019da20b9e)
+        specifier: ^3.11.0
+        version: 3.11.0(30d8862d0d43ceafc31e73019da20b9e)
       '@semantic-release/changelog':
         specifier: ^7.0.0
         version: 7.0.0(semantic-release@25.0.9(supports-color@8.1.1)(typescript@6.0.3))
@@ -2916,8 +2916,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rtorcato/repo-tooling@3.9.1':
-    resolution: {integrity: sha512-leSjjoY+s1T1E767PE7sHBfFIosbm69hXWLYaRfwBqjkc8dJKVTWc9dUU2eeAkwEUNwUctf2i5oQefkrBJjmNQ==}
+  '@rtorcato/repo-tooling@3.11.0':
+    resolution: {integrity: sha512-PChFiam5z09Q2CvioyWgOUJv8SxgZJVP9yHXiZjLYst/jmgYa4BpILoMn3cbbtBE5uQzTVHR/3dcykqsa5HqTg==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
@@ -12163,7 +12163,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
-  '@rtorcato/repo-tooling@3.9.1(30d8862d0d43ceafc31e73019da20b9e)':
+  '@rtorcato/repo-tooling@3.11.0(30d8862d0d43ceafc31e73019da20b9e)':
     dependencies:
       chalk: 5.6.2
       commander: 15.0.0


### PR DESCRIPTION
Closes #212 — with two corrections to what that issue claimed.

## The drift was smaller than reported

`pnpm outdated` said `3.4.0`, but that was a **stale local `node_modules`**. `package.json` declared `^3.9.1` and `pnpm-lock.yaml` pinned `3.9.1`, so CI has been on 3.9.1 the whole time. The real gap was 3.9.1 → **3.11.0** (the issue says 3.10.1; 3.10.2 and 3.11.0 both landed 2026-08-17, after it was written).

`pnpm install` also repairs the stale `node_modules`, so local runs match CI again.

## Why this is low risk

js-common consumes exactly four entry points from this package:

| File | Entry point |
|---|---|
| `tsconfig.json:2` | `typescript/base` |
| `biome.json:3` | `biome` |
| `commitlint.config.mjs:1` | `commitlint/config` |
| `release.config.mjs:1` | `semantic-release/github` |

Comparing `v3.9.1...v3.11.0` (35 files), **the only file changed under `tooling/` is `tooling/claude/repo-tooling.md`** — documentation. Everything else is the CLI, its tests and docs, and nothing here invokes that CLI. v3.11.0's one behaviour change (squash as the only merge method in `GITHUB_STANDARD`, repo-tooling#415) is a checker this repo doesn't run — and its settings already have `allow_merge_commit: false, allow_rebase_merge: false`.

## The audit claim doesn't hold — answered, not acted on

#212 says the 38 advisories "run through this dev dep's own chain." They don't. repo-tooling's runtime `dependencies` are only `chalk, commander, diff, fs-extra, inquirer`; semantic-release, vitest, esbuild and the rest are **optional `peerDependencies`**, so pnpm merely routes paths through it. The real owners — all already at their latest versions, so no bump fixes them:

| Source | Advisories |
|---|---|
| semantic-release + plugins | `handlebars` (incl. the 1 critical), `lodash-es`, `undici` |
| `@docusaurus/*`, `@easyops-cn/docusaurus-search-local` | `serialize-javascript`, `uuid`, `image-size`, `brace-expansion` |
| `vitest`, `@vitest/coverage-v8` | `vite`, `esbuild` |
| `rimraf`, `@commitlint/cli` | `brace-expansion`, `fast-uri` |

Left deliberately: `pnpm audit` runs **nowhere** in CI, so they gate nothing, and `package.json#files` ships only `dist` + markdown, so no consumer is exposed. The vulnerable `uuid` is Docusaurus's nested copy — this repo's runtime `uuid` is `^14.0.1`, well past the `>=11.1.1` patch line. Clearing them would need ~10 `pnpm.overrides` pins to maintain and later unwind for no real reduction in risk. Worth revisiting only if `pnpm audit` becomes a CI gate.

TypeScript deliberately untouched — `.github/dependabot.yml` pins it below 7 because typedoc's peers cap at 6.0.x.

## Verification

```
pnpm typecheck                                clean
pnpm check                                    151 files, no fixes
pnpm test                                     53 files, 417 tests passed
pnpm --filter @rtorcato/js-common-docs build  SUCCESS
node -p "require('.../repo-tooling/package.json').version"   3.11.0
```

Test count is 53/417 rather than the earlier 54/418 — that's the deleted `src/security/probe.test.ts` scratch probe, nothing else.

Release config re-checked, since this bump touches the package supplying that preset:

```
plugins: commit-analyzer, release-notes-generator, github, npm
git dropped: true   changelog dropped: true
npm kept: true      github kept: true
```
