### PR TITLE
fix(ci): redeploy the docs from main after a release, not from the tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ permissions:
     issues: write
     pull-requests: write
     id-token: write
+    # Lets the release job dispatch docs.yml after a publish, so the changelog
+    # page (built from the GitHub Releases API) picks the new version up.
+    actions: write
 
 jobs:
     check-skip:
@@ -316,6 +319,30 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
               run: npx semantic-release
+
+            # The changelog page is built from the GitHub Releases API at docs
+            # build time, so a publish only reaches the site once the site is
+            # rebuilt. docs.yml cannot subscribe to `release` itself: that event
+            # runs with `github.ref` set to the tag, and the `github-pages`
+            # environment only accepts deployments from `main` — the build
+            # succeeds and the deploy is rejected. Dispatching on `main` instead
+            # keeps that protection intact.
+            - name: 📘 Redeploy the docs after a publish
+              # The publish has already happened by this point, so a hiccup here
+              # must not fail the job — that would fire the reporter below and
+              # open an issue saying nothing was published, which would be a lie.
+              # Worst case the docs refresh on the next apps/docs change.
+              continue-on-error: true
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  tag=$(git tag --points-at HEAD | head -1)
+                  if [ -z "$tag" ]; then
+                      echo "No tag on HEAD — semantic-release published nothing. Skipping."
+                      exit 0
+                  fi
+                  echo "Published $tag — dispatching docs.yml on main."
+                  gh workflow run docs.yml --ref main
 
             # Releases failed silently from 2026-08-08 to 2026-08-11 because nothing
             # surfaced the failure — every merge in between was a `test:` commit that

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,11 +7,14 @@ on:
             - 'apps/docs/**'
             - '.github/workflows/docs.yml'
             - 'pnpm-workspace.yaml'
-    # The changelog page is built from GitHub Releases at build time
-    # (scripts/sync-changelog.mjs), so a release has to redeploy the site or the
-    # published page silently stops at whatever the last apps/docs change saw.
-    release:
-        types: [published]
+    # A release must redeploy the site, or the changelog page — built from the
+    # GitHub Releases API by scripts/sync-changelog.mjs — silently stops at
+    # whatever the last apps/docs change saw. That is done by the `release` job
+    # in ci.yml dispatching this workflow on `main`, NOT by subscribing to the
+    # `release` event here: that event runs with `github.ref` set to the tag,
+    # and the `github-pages` environment only accepts deployments from `main`,
+    # so the build succeeds and the deploy is rejected with "Tag vX.Y.Z is not
+    # allowed to deploy to github-pages due to environment protection rules".
     workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Fixes a bug I introduced in #213.

## The trigger can never deploy

#213 added `release: [published]` to `docs.yml` so a publish would refresh the changelog page. It can't work: a `release` event runs with `github.ref` set to the **tag**, and the `github-pages` environment has a deployment branch policy allowing only `main`.

Observed on the v3.0.0 release — `build` succeeded, `deploy` failed:

```
Tag "v3.0.0" is not allowed to deploy to github-pages due to
environment protection rules.
```

```
$ gh api repos/rtorcato/js-common/environments/github-pages/deployment-branch-policies
branch: main
```

## The fix

The requirement is real — the changelog page is built from the GitHub Releases API at docs build time, so a publish only reaches the site once the site is rebuilt.

So instead of subscribing to `release` in `docs.yml`, `ci.yml`'s `release` job now dispatches `docs.yml` on `main` after semantic-release succeeds. That **satisfies** the branch policy rather than loosening it — no change to the environment protection.

- Needs `actions: write` on the workflow.
- Skipped when semantic-release published nothing (`git tag --points-at HEAD` is empty), so an ordinary merge doesn't redeploy the site.
- `continue-on-error: true`, because the publish has already happened by then. Without it, a failed dispatch would trip the `if: failure()` reporter directly below and open an issue saying *"Nothing was published"* — which would be false. Worst case the docs refresh on the next `apps/docs` change.

The removed trigger in `docs.yml` is replaced by a comment recording why it isn't there, so it doesn't get re-added.

## Verification

Both workflows re-parsed after editing:

```
ci.yml   -> OK | triggers: push, pull_request, merge_group, workflow_dispatch
docs.yml -> OK | triggers: push, workflow_dispatch
ci permissions: {contents, issues, pull-requests, id-token, actions: write}
release steps: … Run semantic-release → Redeploy the docs after a publish → Report release failure
step continue-on-error: true
```

The dispatch path itself is proven: running `gh workflow run docs.yml --ref main` by hand deploys successfully, which is also how the 3.0.0 page was published while this fix was pending. The end-to-end path gets its real exercise on the next release.
