### PR TITLE
fix(release): stop failing the release over courtesy comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,21 +347,59 @@ jobs:
             # Releases failed silently from 2026-08-08 to 2026-08-11 because nothing
             # surfaced the failure — every merge in between was a `test:` commit that
             # correctly produced no release, so the breakage stayed invisible.
+            # Did anything actually ship? semantic-release can fail *after* the
+            # publish — its `success` lifecycle runs once npm and the GitHub
+            # release are already done — so a failed job does not imply a failed
+            # release. Resolve it here rather than letting the reporter guess.
+            - name: 🔎 Determine whether the release shipped
+              id: shipped
+              if: failure()
+              run: |
+                  git fetch --tags --quiet || true
+                  tag=$(git tag --points-at HEAD | head -1)
+                  if [ -n "$tag" ]; then
+                      echo "tag=$tag" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "tag=" >> "$GITHUB_OUTPUT"
+                  fi
+
+            # Releases failed silently from 2026-08-08 to 2026-08-11 because nothing
+            # surfaced the failure — every merge in between was a `test:` commit that
+            # correctly produced no release, so the breakage stayed invisible.
             - name: 🔔 Report release failure
               if: failure()
               uses: actions/github-script@v9
               with:
                   script: |
+                      const tag = '${{ steps.shipped.outputs.tag }}'
+                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+                      // Never assert "nothing was published" without checking — #215
+                      // was filed saying exactly that about a release that had
+                      // already put 3.0.0 on npm, because ~30 courtesy comments
+                      // 503'd after the publish.
+                      const outcome = tag
+                        ? [
+                            `**\`${tag}\` was published.** The job failed *after* the release completed,`,
+                            'so npm and the GitHub release are fine — check which post-publish step',
+                            'failed before assuming anything is broken.',
+                          ]
+                        : [
+                            '**Nothing was published.** No tag exists on this commit, so the job',
+                            'failed before or during the release itself. Releases stay blocked',
+                            'until this is fixed.',
+                          ]
                       await github.rest.issues.create({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
-                        title: `Release failed on ${context.sha.slice(0, 7)}`,
+                        title: tag
+                          ? `Release job failed after publishing ${tag}`
+                          : `Release failed on ${context.sha.slice(0, 7)}`,
                         body: [
                           `The \`release\` job failed on \`${context.sha}\`.`,
                           '',
-                          `[View the run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                          ...outcome,
                           '',
-                          'Nothing was published. Releases stay blocked until this is fixed.',
+                          `[View the run](${runUrl})`,
                         ].join('\n'),
                         labels: ['bug'],
                       })

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -25,9 +25,28 @@ import preset from '@rtorcato/repo-tooling/semantic-release/github'
 // here — CI just has to run the release job on that branch too (see ci.yml).
 const DROPPED = new Set(['@semantic-release/git', '@semantic-release/changelog'])
 
-const plugins = preset.plugins.filter(
-	(plugin) => !DROPPED.has(Array.isArray(plugin) ? plugin[0] : plugin)
-)
+// @semantic-release/github's `success` step posts a "included in version X"
+// comment on every issue and PR referenced in the release notes. That is one
+// API call each, after the npm publish and the GitHub release have already
+// happened — so when those calls fail, semantic-release exits non-zero on a
+// release that fully shipped.
+//
+// 3.0.0 did exactly that (#215): the release and the publish both succeeded at
+// 17:06, then GitHub's API started returning 503 "No server is currently
+// available" and ~30 comment calls failed until semantic-release gave up at
+// 17:12. A release carrying 76 commits references dozens of PRs, so the
+// blast radius grows with the size of the release — the bigger and more
+// important the release, the likelier it fails on a cosmetic step.
+//
+// The comments are noise here anyway: PRs are squash-merged and closed long
+// before they ship. Turning them off removes the failure mode entirely.
+const plugins = preset.plugins
+	.filter((plugin) => !DROPPED.has(Array.isArray(plugin) ? plugin[0] : plugin))
+	.map((plugin) =>
+		Array.isArray(plugin) && plugin[0] === '@semantic-release/github'
+			? [plugin[0], { ...plugin[1], successComment: false }]
+			: plugin
+	)
 
 export default {
 	...preset,


### PR DESCRIPTION
Closes #215 — an issue the reporter filed about itself, and got wrong on both claims.

## What actually happened

| time (UTC) | event |
|---|---|
| 17:06:18 | GitHub Release `v3.0.0` created ✅ |
| 17:06:27 | `npm publish` succeeded ✅ |
| 17:07:17 → 17:12:14 | ~30 `successComment` calls fail with `503 No server is currently available` |
| 17:12:14 | semantic-release exits `1` |
| — | reporter files #215: *"Nothing was published. Releases stay blocked."* |

Both statements in that issue are false. `npm view @rtorcato/js-common version` → `3.0.0`; `gh release view v3.0.0` → published, not draft.

The failure is entirely in `@semantic-release/github`'s **`success` lifecycle**, which posts a "included in version X" comment on every issue and PR referenced in the release notes — after npm and the GitHub release are already done. GitHub's API was degraded in that window (I hit the same 503 twice opening PRs by hand around then).

## Two faults, one each side

**Cause — `successComment: false`.** One API call per referenced PR, all post-publish. A release carrying 76 commits references dozens of them, so *the blast radius grows with the size of the release* — the bigger and more important the release, the likelier it dies on a cosmetic step. The comments are noise in this repo anyway: PRs are squash-merged and closed long before they ship. Disabling removes the failure mode instead of narrowing it.

Applied as a `.map()` over the preset plugin so the preset's other options survive — verified:
```
github opts: {"assets":[...],"message":"...","labels":false,"successComment":false}
successComment disabled: true   labels preserved: true   assets preserved: true
```

**Reporting — don't assert what wasn't checked.** The reporter said "Nothing was published" unconditionally on *any* failure of the job. That's false whenever semantic-release fails after publishing, and it's the dangerous direction to be wrong in: it invites someone to re-run or hand-publish a release that already went out. It now resolves whether a tag exists on HEAD first, and reports accordingly with a distinct title so the two cases don't blur together in the issue list:

```
TITLE: Release job failed after publishing v3.0.0
**`v3.0.0` was published.** The job failed *after* the release completed,
so npm and the GitHub release are fine — check which post-publish step
failed before assuming anything is broken.

TITLE: Release failed on 92c5012
**Nothing was published.** No tag exists on this commit, so the job
failed before or during the release itself. Releases stay blocked
until this is fixed.
```

The tag check is the same one the docs-redeploy step directly above already uses, so both post-publish steps now agree on what "shipped" means.

The "releases failed silently 2026-08-08 → 08-11" comment is preserved — that's why this reporter exists, and this change keeps it firing, just honestly.

## Verification

```
ci.yml parsed OK; release steps in order:
  … Run semantic-release → Redeploy the docs after a publish
  → Determine whether the release shipped (id=shipped, if=failure())
  → Report release failure (if=failure())

release.config.mjs → plugins: commit-analyzer, release-notes-generator, github, npm
                     git dropped ✔  changelog dropped ✔

pnpm typecheck  clean
pnpm check      151 files, no fixes
pnpm test       417 passed
```

Reporter body rendering was simulated for both branches offline (output above). The real exercise is the next release.
