### PR TITLE
docs(cli): say what `system node-version` actually prints

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -124,9 +124,14 @@ js-common system pid
 # Get process uptime in seconds
 js-common system uptime
 
-# Get Node.js major version
+# Get the full Node.js version string, e.g. v22.23.1
 js-common system node-version
 ```
+
+Note the CLI verbs and the library exports are deliberately different things, and
+`js-common add` prints the export, not the verb. `system node-version` prints
+`process.version` in full; the export it points you at, `getNodeMajorVersion`,
+returns just the major as a number (`22`).
 
 That is the whole command surface. The CLI is a shop window for the library, not a
 port of it — most of the package (`file`, `security`, `validation`, and the rest of


### PR DESCRIPTION
Found by running the **published** 3.0.0 CLI rather than reading the source.

`CLI.md` claimed *"Get Node.js major version"*. `cli.ts:374` prints `process.version` in full:

```
$ npx js-common system node-version
v22.23.1          ← not 22
```

Also records why the two differ, because it reads like a bug otherwise: the catalog maps this verb to the `getNodeMajorVersion` export, which *does* return `22`. So `js-common add` shows you a function whose output doesn't match what the verb just printed. The verbs and the exports are deliberately different things (`catalog.ts` says so in its header) — that's now stated where someone hitting the discrepancy will actually look.

Same class as the drift #210 cleared, and the parity test added there **can't** catch it: that asserts every catalog verb is a registered command, not that the docs describe what it does.

Audited the rest of the surface at the same time — `date today/now/between`, all five `math` verbs, `text capitalize/title`, `system pid/uptime` all match their descriptions. This was the only one.
