### PR TITLE
chore(deps): drop the three unused date dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A comprehensive set of common JavaScript and TypeScript utilities for Node.js pr
 - **TypeScript** — full type definitions, JSDoc on every public API
 - **CLI included** — optional binary for use in scripts and terminals
 - **Modular** — one module per concern, 44 subpaths
-- **Minimal runtime deps** — only `date-fns`, `date-fns-tz`, `luxon`, `pino`, `uuid`, `short-uuid`, `zod`. CLI packages (`chalk`, `commander`, `figlet`, …) are `optionalDependencies` and only needed for the CLI.
+- **Minimal runtime deps** — only `pino`, `uuid`, `short-uuid`, `zod`. CLI packages (`chalk`, `commander`, `figlet`, …) are `optionalDependencies` and only needed for the CLI.
 
 ## Installation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,7 @@ We take security seriously. If you discover a security vulnerability, please rep
 
 This library follows security best practices:
 
-- ✅ **Minimal Runtime Dependencies**: Library utilities depend on a small, audited set (`date-fns`, `date-fns-tz`, `luxon`, `pino`, `short-uuid`, `uuid`, `zod`). The CLI-only packages (`@inquirer/prompts`, `chalk`, `chalk-animation`, `commander`, `figlet`, `gradient-string`) are `optionalDependencies` used by the `js-common` binary, not by any importable subpath — there is no `./cli` export.
+- ✅ **Minimal Runtime Dependencies**: Library utilities depend on a small, audited set (`pino`, `short-uuid`, `uuid`, `zod`). The CLI-only packages (`@inquirer/prompts`, `chalk`, `chalk-animation`, `commander`, `figlet`, `gradient-string`) are `optionalDependencies` used by the `js-common` binary, not by any importable subpath — there is no `./cli` export.
 - ✅ **Type Safety**: Full TypeScript support prevents many runtime errors
 - ✅ **Secure Defaults**: `generateSecureToken` uses `randomBytes` from `node:crypto`. The `Math.random`-based helpers in `random` are never an acceptable substitute for it.
 - ✅ **Automated Updates**: Dependabot keeps dependencies current

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -72,7 +72,7 @@ See [Tree-shaking & imports](./guides/tree-shaking.md) for the full explanation.
 - **45+ subpath modules**, one concern per module — see the [Module overview](./modules/overview.md).
 - **Strict TypeScript** — generics preserved end-to-end; `any` avoided in public APIs.
 - **JSDoc on every public function** — hover docs in VS Code, JetBrains, and Cursor.
-- **Minimal runtime deps** — only `date-fns`, `date-fns-tz`, `luxon`, `pino`, `uuid`, `short-uuid`, `zod`. CLI-only packages live in `optionalDependencies`.
+- **Minimal runtime deps** — only `pino`, `uuid`, `short-uuid`, `zod`. CLI-only packages live in `optionalDependencies`.
 - **Tested** — Vitest with coverage; CI runs on every commit.
 
 ### Highlights

--- a/package.json
+++ b/package.json
@@ -253,7 +253,6 @@
     "@size-limit/preset-small-lib": "^13.0.3",
     "@types/chalk-animation": "^1.6.3",
     "@types/figlet": "^1.7.0",
-    "@types/luxon": "^3.7.1",
     "@types/node": "^26.1.2",
     "@vitest/coverage-v8": "^4.0.17",
     "cross-env": "^10.1.0",
@@ -269,9 +268,6 @@
     "vitest": "^4.0.17"
   },
   "dependencies": {
-    "date-fns": "^4.1.0",
-    "date-fns-tz": "^3.2.0",
-    "luxon": "^3.7.2",
     "pino": "^10.1.0",
     "short-uuid": "^6.0.3",
     "uuid": "^14.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,6 @@ importers:
 
   .:
     dependencies:
-      date-fns:
-        specifier: ^4.1.0
-        version: 4.4.0
-      date-fns-tz:
-        specifier: ^3.2.0
-        version: 3.2.0(date-fns@4.4.0)
-      luxon:
-        specifier: ^3.7.2
-        version: 3.7.2
       pino:
         specifier: ^10.1.0
         version: 10.3.1
@@ -69,9 +60,6 @@ importers:
       '@types/figlet':
         specifier: ^1.7.0
         version: 1.7.0
-      '@types/luxon':
-        specifier: ^3.7.1
-        version: 3.7.3
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
@@ -3334,9 +3322,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/luxon@3.7.3':
-    resolution: {integrity: sha512-pE7BSbKHiojpl4v7iEzdfFLXXJaH5RPJxI3Wr4x3HU59l83PJfhcUx4mGPWq245+DCAENAzRF/+ZoYr2tJCe/g==}
-
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -4388,14 +4373,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  date-fns-tz@3.2.0:
-    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
-    peerDependencies:
-      date-fns: ^3.0.0 || ^4.0.0
-
-  date-fns@4.4.0:
-    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -5869,10 +5846,6 @@ packages:
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
-
-  luxon@3.7.2:
-    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
-    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -12594,8 +12567,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/luxon@3.7.3': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -13809,12 +13780,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  date-fns-tz@3.2.0(date-fns@4.4.0):
-    dependencies:
-      date-fns: 4.4.0
-
-  date-fns@4.4.0: {}
 
   dateformat@4.6.3:
     optional: true
@@ -15471,8 +15436,6 @@ snapshots:
   lunr-languages@1.21.0: {}
 
   lunr@2.3.9: {}
-
-  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
date-fns, date-fns-tz and luxon were declared as runtime dependencies but
imported by nothing — not src/, not scripts/, not the CLI. Every consumer
was installing three date libraries the package can never reach. @types/luxon
was likewise unused.

The date/datetime/time modules are native-Date helpers, as their own docs
already say. Also corrects the three places that advertised the removed
packages as part of the runtime dependency set.

Closes #219
