### PR TITLE
docs: point the version claims at 4.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,12 +6,13 @@ We actively support the following versions of `@rtorcato/js-common`:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.x.x   | :white_check_mark: |
-| < 3.0   | :x:                |
+| 4.x.x   | :white_check_mark: |
+| < 4.0   | :x:                |
 
-Only the latest major gets fixes. 3.0 moved every helper to exactly one module and
-renamed `sanitizeString` to `stripScriptish` — see [MODULE-BOUNDARIES.md](MODULE-BOUNDARIES.md)
-and the [migration guide](https://rtorcato.github.io/js-common/docs/guides/migration).
+Only the latest major gets fixes. 4.0 removed the exports that only wrapped a
+JavaScript built-in, including the `./sets` and `./interval` modules — see
+[MODULE-BOUNDARIES.md](MODULE-BOUNDARIES.md) and the
+[migration guide](https://rtorcato.github.io/js-common/docs/guides/migration).
 
 ## Reporting a Vulnerability
 

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -103,7 +103,7 @@ See the [full module overview](./modules/overview.md) for the complete list.
 - [**CLI**](./guides/cli.md) — run utilities from your terminal.
 - [**Module overview**](./modules/overview.md) — every subpath with examples.
 - [**API reference**](./api) — auto-generated from the source.
-- [**Migrating to 2.x**](./guides/migration.md) — the only breaking change since 1.x.
+- [**Migrating**](./guides/migration.md) — every breaking change, newest first.
 
 ## Project
 


### PR DESCRIPTION
Two version claims that the 4.0 work left stale — both pre-existing, neither caught by `check:readme` because they name versions rather than exports.

- **`apps/docs/docs/index.mdx`** called the migration guide *"Migrating to 2.x — the only breaking change since 1.x"*. That stopped being true when 3.0 shipped and is now wrong by two majors, while linking to a guide that documents three upgrades. It no longer names a version.
- **`SECURITY.md`** listed `3.x.x` as the supported line with `< 3.0` unsupported, and summarised the 3.0 changes. Now `4.x.x` / `< 4.0`, summarising 4.0.

Docs only — no source, no exports, no version bump. `semantic-release` will not cut a release from a `docs:` commit, so this can merge before or after the 4.0.0 approval without affecting it.