### PR TITLE
chore(docs): silence the baseUrl deprecation on TypeScript 6

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "@docusaurus/tsconfig",
 	"compilerOptions": {
-		"baseUrl": "."
+		"baseUrl": ".",
+		"ignoreDeprecations": "6.0"
 	},
 	"include": ["src/", "docusaurus.config.ts", "sidebars.ts"],
 	"exclude": [".docusaurus", "build", "node_modules"]


### PR DESCRIPTION
The editor shows TS5101 on `apps/docs/tsconfig.json` every time it's opened: *"Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0."*

### Why the obvious fix is wrong

Deleting our `baseUrl` does **not** work. The option is set by `@docusaurus/tsconfig` itself, together with `paths: {"@site/*": ["./*"]}` — and `paths` resolves relative to `baseUrl`. `tsc --showConfig` with our line removed:

```
"baseUrl": "../../node_modules/.pnpm/@docusaurus+tsconfig@3.10.2/node_modules/@docusaurus/tsconfig"
```

So `@site/*` would resolve inside the `@docusaurus/tsconfig` package directory instead of `apps/docs`. Silently — the deprecation error masks the fallout, and the inherited `baseUrl` keeps the error firing anyway. The local `baseUrl: "."` is what re-anchors it.

### What this does

Adds `ignoreDeprecations: "6.0"`, which is the only lever available while the option comes from a dependency. This makes the file **byte-identical to `api-common/apps/docs/tsconfig.json` and `browser-common/apps/docs/tsconfig.json`**, which already carry it — js-common was the outlier.

Verified: `tsc --noEmit -p apps/docs/tsconfig.json` clean, `@site/*` still resolves to `apps/docs`, root `typecheck` and `biome check` unaffected.

### Known ceiling
TS 7 removes `baseUrl` outright and `ignoreDeprecations: "6.0"` stops being accepted. The real fix then belongs upstream in `@docusaurus/tsconfig`. `repo-tooling` is already on TS 7 and already failing this way — being fixed separately, since its docs tsconfig is standalone rather than extending Docusaurus.