### PR TITLE
docs: tint sibling card names with each package's accent

### DIFF
--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -355,7 +355,9 @@ function Siblings(): ReactElement {
 				{SIBLINGS.map((s) => (
 					<Link key={s.name} href={s.href} className={styles.card}>
 						<div className={styles.cardHead}>
-							<div className={styles.cardName}>{s.name}</div>
+							<div className={styles.cardName} style={{ color: s.accent }}>
+								{s.name}
+							</div>
 							<div className={styles.cardCount}>{s.dest} ↗</div>
 						</div>
 						<p className={styles.cardDesc}>{s.tagline}</p>


### PR DESCRIPTION
The **Sibling projects** cards on the docs homepage render every package name in the default heading colour, so the grid reads as one flat block.

`siblings()` from `@rtorcato/shared-docs` already returns an `accent` for every entry (`#e879f9`, `#a78bfa`, `#3ecf8e`, …) — `apps/docs/src/pages/index.tsx` just never used it. The other family docs sites apply it to the package name; this matches them.

One-line change. Verified with `pnpm build` in `apps/docs`: all 9 accent values land inline in the emitted HTML.