### PR TITLE
docs: stack the Use-with-AI cards full width, skills CLI first

### DIFF
--- a/apps/docs/src/pages/index.module.css
+++ b/apps/docs/src/pages/index.module.css
@@ -311,6 +311,12 @@
 	color: var(--jc-text);
 }
 
+/* Use-with-AI: one full-width card per target. Three columns squeezed the
+   install commands into different wrap points, so nothing lined up. */
+.aiStack {
+	display: grid;
+	gap: 16px;
+}
 /* Use-with-AI install snippets */
 .aiCode {
 	margin: 12px 0 0;

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -372,7 +372,14 @@ type AiTarget = {
 	code: string
 }
 
+// The skills CLI works everywhere, so it leads; the other two are shortcuts for
+// the tools that have one.
 const AI_TARGETS: AiTarget[] = [
+	{
+		title: 'Any coding agent',
+		desc: <>Pull the skill into any tool the skills CLI supports.</>,
+		code: 'npx skills add https://github.com/rtorcato/js-common \\\n  --skill js-common',
+	},
 	{
 		title: 'Claude Code',
 		desc: <>The repo is its own plugin marketplace — add it, then install the skill.</>,
@@ -387,11 +394,6 @@ const AI_TARGETS: AiTarget[] = [
 			</>
 		),
 		code: 'node_modules/@rtorcato/js-common/AGENTS.md',
-	},
-	{
-		title: 'Anything else',
-		desc: <>Pull the skill into any tool the skills CLI supports.</>,
-		code: 'npx skills add https://github.com/rtorcato/js-common \\\n  --skill js-common',
 	},
 ]
 
@@ -413,7 +415,7 @@ function UseWithAI(): ReactElement {
 					Read the rules →
 				</Link>
 			</div>
-			<div className={styles.catGrid}>
+			<div className={styles.aiStack}>
 				{AI_TARGETS.map((t) => (
 					<div key={t.title} className={styles.pillar}>
 						<div className={styles.pillarTitle}>{t.title}</div>


### PR DESCRIPTION
The three **Use with AI** cards ride on `.catGrid` (3 columns), so each one got a third of the row for an install command of a very different length. The commands wrapped at different points and the cards never lined up.

- one full-width card per target (`.aiStack`, single-column grid)
- the `npx skills add` card leads — it works with any agent, so it's the sensible default; retitled *Anything else* → *Any coding agent*
- Claude Code and the `AGENTS.md` path follow as shortcuts for the tools that have one

Verified with `pnpm build` in `apps/docs`.