### PR TITLE
fix(ci): stop cancelling release runs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    # Only cancel superseded PR runs. A push to main carries the release job, and
+    # killing that mid-publish can leave a tag with no npm publish behind it — so
+    # back-to-back pushes queue instead of cancelling.
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
     contents: write


### PR DESCRIPTION
The `release` environment is a wall of red deployments. They aren't failures — they're **cancellations**.

`ci.yml` sets:

```yaml
concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true
```

That applies to `main` too, so every push to `main` kills the previous run — and the release job rides in that run. Recent runs on `main` bear it out: `#227`, `#228`, `#229`, `#231`, `#232` all show `release: cancelled` with every other job green.

Two problems:

1. **Noise** — the release environment looks broken when nothing is wrong.
2. **A real hazard** — a cancel landing inside semantic-release's publish window can leave a git tag and GitHub Release with no npm publish behind it. (`browser-common` hit exactly that class of bug earlier.) Nothing is orphaned right now: npm and the newest tag are both `v4.0.0`.

Fix: cancel only superseded `pull_request` runs. Pushes to `main` queue behind each other, which is what you want for a serialized release.

`browser-common` has the identical line — a matching PR is up there.