### PR TITLE
docs: import the shared UseWithAI instead of the local copy

### DIFF
--- a/apps/docs/src/pages/index.module.css
+++ b/apps/docs/src/pages/index.module.css
@@ -311,24 +311,6 @@
 	color: var(--jc-text);
 }
 
-/* Use-with-AI: one full-width card per target. Three columns squeezed the
-   install commands into different wrap points, so nothing lined up. */
-.aiStack {
-	display: grid;
-	gap: 16px;
-}
-/* Use-with-AI install snippets */
-.aiCode {
-	margin: 12px 0 0;
-	padding: 12px 14px;
-	background: var(--jc-code-bg);
-	border: 1px solid var(--jc-border);
-	border-radius: 10px;
-	font: 500 12.5px / 1.7 var(--ifm-font-family-monospace);
-	color: var(--jc-text);
-	overflow: auto;
-}
-
 /* ---------- Responsive ---------- */
 @media (max-width: 996px) {
 	.pillarGrid {

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import Link from '@docusaurus/Link'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 import { siblings } from '@rtorcato/shared-docs'
+import UseWithAI from '@rtorcato/shared-docs/components/UseWithAI'
 import Layout from '@theme/Layout'
 import clsx from 'clsx'
 import { type ReactElement, useEffect, useState } from 'react'
@@ -368,68 +369,6 @@ function Siblings(): ReactElement {
 	)
 }
 
-type AiTarget = {
-	title: string
-	desc: ReactElement
-	code: string
-}
-
-// The skills CLI works everywhere, so it leads; the other two are shortcuts for
-// the tools that have one.
-const AI_TARGETS: AiTarget[] = [
-	{
-		title: 'Any coding agent',
-		desc: <>Pull the skill into any tool the skills CLI supports.</>,
-		code: 'npx skills add https://github.com/rtorcato/js-common \\\n  --skill js-common',
-	},
-	{
-		title: 'Claude Code',
-		desc: <>The repo is its own plugin marketplace — add it, then install the skill.</>,
-		code: '/plugin marketplace add rtorcato/js-common\n/plugin install js-common@js-common',
-	},
-	{
-		title: 'Cursor, Copilot, Codex',
-		desc: (
-			<>
-				They read <code>AGENTS.md</code>. It ships in the npm tarball, so it is already in your{' '}
-				<code>node_modules</code>.
-			</>
-		),
-		code: 'node_modules/@rtorcato/js-common/AGENTS.md',
-	},
-]
-
-function UseWithAI(): ReactElement {
-	return (
-		<section className={styles.section}>
-			<div className={styles.sectionHead}>
-				<div>
-					<h2 className={styles.h2}>Use with AI</h2>
-					<p className={styles.sub}>
-						One skill teaches your coding agent the subpath-import rules, the three error idioms and
-						which modules are Node-only.
-					</p>
-				</div>
-				<Link
-					className={styles.viewAll}
-					href="https://github.com/rtorcato/js-common/blob/main/AGENTS.md"
-				>
-					Read the rules →
-				</Link>
-			</div>
-			<div className={styles.aiStack}>
-				{AI_TARGETS.map((t) => (
-					<div key={t.title} className={styles.pillar}>
-						<div className={styles.pillarTitle}>{t.title}</div>
-						<div className={styles.pillarDesc}>{t.desc}</div>
-						<pre className={styles.aiCode}>{t.code}</pre>
-					</div>
-				))}
-			</div>
-		</section>
-	)
-}
-
 export default function Home(): ReactElement {
 	return (
 		<Layout
@@ -440,7 +379,13 @@ export default function Home(): ReactElement {
 				<Hero />
 				<Pillars />
 				<Categories />
-				<UseWithAI />
+				<UseWithAI
+					repo="rtorcato/js-common"
+					plugin="js-common"
+					skill="js-common"
+					pkg="@rtorcato/js-common"
+					blurb="One skill teaches your coding agent the subpath-import rules, the three error idioms and which modules are Node-only."
+				/>
 				<Siblings />
 			</main>
 		</Layout>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,7 +163,7 @@ importers:
         version: 1.62.1
       '@rtorcato/shared-docs':
         specifier: github:rtorcato/shared-docs
-        version: https://codeload.github.com/rtorcato/shared-docs/tar.gz/5fb0ae8ff63da6dcc027b2931ee7df3f7a48ce60(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: https://codeload.github.com/rtorcato/shared-docs/tar.gz/b9fa5cfc136a76359762b9dbcb072279fe14758d(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.18
@@ -3019,8 +3019,8 @@ packages:
       vitest:
         optional: true
 
-  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/5fb0ae8ff63da6dcc027b2931ee7df3f7a48ce60':
-    resolution: {gitHosted: true, integrity: sha512-AmENptbpXoosikICI9c7ZPgzuhZIygdMgUIIImCA9C3gK8/hYtYKtupNSwSsertxa/rVCeK0pdw4vgAO+J+vpA==, tarball: https://codeload.github.com/rtorcato/shared-docs/tar.gz/5fb0ae8ff63da6dcc027b2931ee7df3f7a48ce60}
+  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/b9fa5cfc136a76359762b9dbcb072279fe14758d':
+    resolution: {gitHosted: true, integrity: sha512-SSZhfFdM+b3eTmyYfSMrAJM+/aMojHP6igyiWwPs5qTGGx79BhDbtaeQqiGJQLj9ge4ka9R81Ffn/hWhqVT1EA==, tarball: https://codeload.github.com/rtorcato/shared-docs/tar.gz/b9fa5cfc136a76359762b9dbcb072279fe14758d}
     version: 1.2.0
     engines: {node: '>=22'}
     peerDependencies:
@@ -12174,7 +12174,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/5fb0ae8ff63da6dcc027b2931ee7df3f7a48ce60(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/b9fa5cfc136a76359762b9dbcb072279fe14758d(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)


### PR DESCRIPTION
Closes #236.

shared-docs#46 landed, so `@rtorcato/shared-docs/components/UseWithAI` now *is* this repo's 3-card design. This deletes the local `AI_TARGETS` / `AiTarget` / `UseWithAI` and the `.aiStack` / `.aiCode` CSS and imports the shared component instead.

- Bumps the `github:rtorcato/shared-docs` lockfile pin to `b9fa5cf` (the commit that shipped the component). shared-docs#44 — stop tracking `dist/` — is still open, so the tracked-`dist` route still works; if that lands, this repo has to move to the npm dep.
- Keeps the js-common-specific intro via the `blurb` prop rather than the generic default.
- The commands now render through the shared `CommandBlock`, so each gets a copy button instead of a plain `<pre>`.

**One visual difference worth eyeballing:** the shared component styles its own "Read the rules →" as a plain `--ifm-color-primary` text link, whereas this page's local `.viewAll` is a gold outlined pill. Colours still match (`--ifm-color-primary` == `--jc-gold` in both modes), but that one link no longer matches the pill on the Categories section directly above it. Fixing it properly is a shared-docs change, not a js-common one.

Verified: `pnpm typecheck`, `pnpm check`, `apps/docs` typecheck, and `apps/docs` `pnpm build` all pass; confirmed the shared component's CSS module is emitted into the built bundle.